### PR TITLE
fix: add css for password input field

### DIFF
--- a/Client/src/Pages/Login/index.css
+++ b/Client/src/Pages/Login/index.css
@@ -45,6 +45,12 @@
   font-size: var(--env-var-font-size-medium);
 }
 
+#login-password-input {
+  width: 308px;
+  height: 11px;
+  font-size: var(--env-var-font-size-medium);
+}
+
 .login-form-password-options {
   display: flex;
   align-items: center;


### PR DESCRIPTION
Per issue  #193  : The password input field styling appears to be broken.  
  
The .css file for this component did not include any styling for the password input. I've added this to conform to the same styling as the Email input field and tested locally.  
  
![image](https://github.com/bluewave-labs/bluewave-uptime/assets/121157983/f1473435-7164-44f1-bbe4-8bd0e59687ae)
  
I note that this issue also seems to have been previously fixed, then reverted again in a closed PR, #205