### PR TITLE
Connected password form to redux, resolves #214

### DIFF
--- a/Client/src/Components/TextFields/Password/PasswordTextField.jsx
+++ b/Client/src/Components/TextFields/Password/PasswordTextField.jsx
@@ -10,6 +10,7 @@ import Visibility from "@mui/icons-material/Visibility";
 /**
  * @component
  * @param {Object} props
+ * @param {string} props.value - The current value of the text field
  * @param {function} props.onChange - The function to call when the text field changes (optional)
  * @param {string} props.id - Unique ID for the text field (optional)
  * @param {string} props.label - The label text displayed above the text field (optional)
@@ -23,6 +24,7 @@ import Visibility from "@mui/icons-material/Visibility";
  * @returns {JSX.Element} - Renders the password text field component with dynamic icon display
  */
 const PasswordTextField = ({
+  value,
   onChange,
   id,
   label = "Password",
@@ -53,6 +55,7 @@ const PasswordTextField = ({
       <div className="password-text-field-title">{label}</div>
       <div className="password-text-field">
         <TextField
+          value={value}
           onChange={onChange}
           type={visibility ? "text" : "password"}
           autoComplete={autoComplete}

--- a/Client/src/Features/Auth/authSlice.js
+++ b/Client/src/Features/Auth/authSlice.js
@@ -47,8 +47,10 @@ export const update = createAsyncThunk(
       await new Promise((resolve) => setTimeout(resolve, 1500));
 
       const fd = new FormData();
-      fd.append("firstname", form.firstname);
-      fd.append("lastname", form.lastname);
+      form.firstname && fd.append("firstname", form.firstname);
+      form.lastname && fd.append("lastname", form.lastname);
+      form.password && fd.append("password", form.password);
+      form.newPassword && fd.append("newPassword", form.newPassword);
       if (form.file && form.file !== "") {
         const imageResult = await axiosInstance.get(form.file, {
           responseType: "blob",

--- a/Client/src/Validation/validation.js
+++ b/Client/src/Validation/validation.js
@@ -119,7 +119,7 @@ const passwordSchema = joi
 const editPasswordValidation = joi.object({
   // TBD - validation for current password ?
   password: passwordSchema,
-  newpassword: passwordSchema,
+  newPassword: passwordSchema,
   confirm: joi
     .string()
     .trim()
@@ -127,8 +127,8 @@ const editPasswordValidation = joi.object({
       "string.empty": "*Password confirmation is required.",
     })
     .custom((value, helpers) => {
-      const { newpassword } = helpers.prefs.context;
-      if (value !== newpassword) {
+      const { newPassword } = helpers.prefs.context;
+      if (value !== newPassword) {
         return helpers.message("*Passwords do not match.");
       }
       return value;


### PR DESCRIPTION
Connected password form to redux. There are sill some checks to be done. Currently any error from the request will display under the `Password` text field, where we're specifically looking for the "Incorrect password" (403) error only. The easy solution would be to simply check for `action.payload.msg === "Incorrect password"` but that doesn't feel right. Any thoughts? 