### PR TITLE
Update docker compose to bind port 80

### DIFF
--- a/Docker/docker-compose.yaml
+++ b/Docker/docker-compose.yaml
@@ -3,7 +3,7 @@ services:
   client:
     image: uptime_client:latest
     ports:
-      - "5173:5173"
+      - "80:5173"
     env_file:
       - client.env
     depends_on:


### PR DESCRIPTION
Bind port 80 to 5173 so you can just visit `<host>` instead of `<host>:5173` when deployed