### PR TITLE
JobQueue was not deleting jobs correctly due to incorrect  lookup

### DIFF
--- a/Server/controllers/monitorController.js
+++ b/Server/controllers/monitorController.js
@@ -233,9 +233,10 @@ const editMonitor = async (req, res, next) => {
   }
 
   try {
+    const jobBeforeEdit = await req.db.getMonitorById(req, res);
     const editedMonitor = await req.db.editMonitor(req, res);
     // Delete the old job(editedMonitor has the same ID as the old monitor)
-    await req.jobQueue.deleteJob(editedMonitor);
+    await req.jobQueue.deleteJob(jobBeforeEdit);
     // Add the new job back to the queue
     await req.jobQueue.addJob(editedMonitor._id, editedMonitor);
     return res.status(200).json({

--- a/Server/controllers/monitorController.js
+++ b/Server/controllers/monitorController.js
@@ -233,10 +233,10 @@ const editMonitor = async (req, res, next) => {
   }
 
   try {
-    const jobBeforeEdit = await req.db.getMonitorById(req, res);
+    const monitorBeforeEdit = await req.db.getMonitorById(req, res);
     const editedMonitor = await req.db.editMonitor(req, res);
     // Delete the old job(editedMonitor has the same ID as the old monitor)
-    await req.jobQueue.deleteJob(jobBeforeEdit);
+    await req.jobQueue.deleteJob(monitorBeforeEdit);
     // Add the new job back to the queue
     await req.jobQueue.addJob(editedMonitor._id, editedMonitor);
     return res.status(200).json({

--- a/Server/service/jobQueue.js
+++ b/Server/service/jobQueue.js
@@ -231,7 +231,7 @@ class JobQueue {
    */
   async deleteJob(monitor) {
     try {
-      const deleted = await this.queue.removeRepeatable(monitor.id, {
+      const deleted = await this.queue.removeRepeatable(monitor._id, {
         every: monitor.interval,
       });
       if (deleted) {


### PR DESCRIPTION
Updating a job in the JobQueue requires first removing the active job and then readding it with new parameters.

BullMQ `removeRepeatable` requires the exact same parameters that were provided to create a job in order to delete it.

The parameters used to create the job are the monitors ID and `interval` key, as such we need to get the unmodified monitor prior to update in order to remove the job or else the `interval` may change, making the job inaccessible.

Also fixed an error in accessing monitor's `_id` field