### PR TITLE
Notifications removed and readded on monitor edit

### DIFF
--- a/Server/db/mongo/modules/monitorModule.js
+++ b/Server/db/mongo/modules/monitorModule.js
@@ -209,6 +209,8 @@ const deleteMonitorsByUserId = async (userId) => {
 const editMonitor = async (req, res) => {
   const candidateId = req.params.monitorId;
   const candidateMonitor = req.body;
+  candidateMonitor.notifications = undefined;
+
   try {
     const editedMonitor = await Monitor.findByIdAndUpdate(
       candidateId,


### PR DESCRIPTION
A user is able to modify recipients for notifications when they edit a Monitor.

Easiest way of handling this is to drop all notifications currently associated with that Monitor and then add their new ones.

Implemented as such, can revisit if not performant