### PR TITLE
Add instant check at create monitor time, resolves #516

### DIFF
--- a/Server/service/jobQueue.js
+++ b/Server/service/jobQueue.js
@@ -210,6 +210,9 @@ class JobQueue {
    */
   async addJob(jobName, payload) {
     try {
+      // Execute job immediately
+      await this.queue.add(jobName, payload);
+
       await this.queue.add(jobName, payload, {
         repeat: {
           every: payload.interval,


### PR DESCRIPTION
When a monitor is created, immediately add a non-repeateable job to the queue so we have data right away.