### PR TITLE
Removed logical error in check filter for monitor chart, resolves #541

### DIFF
--- a/Client/src/Components/Charts/MonitorDetailsAreaChart/index.jsx
+++ b/Client/src/Components/Charts/MonitorDetailsAreaChart/index.jsx
@@ -60,8 +60,6 @@ const MonitorDetailsAreaChart = ({ checks, filter }) => {
       const checkTime = new Date(checks[i].createdAt).getTime();
       if (now - checkTime < limits[filter]) {
         result.push(checks[i]);
-      } else {
-        break;
       }
     }
     return result;


### PR DESCRIPTION
As checks are ordered oldest -> newest the removed `break` would have been called as soon as there is a check older than the set limit, which stops the chart from populating