### PR TITLE
Fix/be/monitor data pagination, also resolves #567

### DIFF
--- a/Client/src/Pages/Monitors/Details/PaginationTable/index.jsx
+++ b/Client/src/Pages/Monitors/Details/PaginationTable/index.jsx
@@ -1,0 +1,121 @@
+import PropTypes from "prop-types";
+import {
+  TableContainer,
+  Table,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableBody,
+  TableFooter,
+  TablePagination,
+} from "@mui/material";
+
+import { useState, useEffect } from "react";
+import { useSelector } from "react-redux";
+import axiosInstance from "../../../../Utils/axiosConfig";
+import { StatusLabel } from "../../../../Components/Label";
+
+const PaginationTable = ({ monitorId, filter }) => {
+  const { authToken } = useSelector((state) => state.auth);
+  const [checks, setChecks] = useState([]);
+  const [checksCount, setChecksCount] = useState(0);
+  const [paginationController, setPaginationController] = useState({
+    page: 0,
+    rowsPerPage: 5,
+  });
+
+  useEffect(() => {
+    const fetchPage = async () => {
+      try {
+        const res = await axiosInstance.get(
+          `/checks/${monitorId}?sortOrder=desc&filter=${filter}&page=${paginationController.page}&rowsPerPage=${paginationController.rowsPerPage}`,
+          {
+            headers: {
+              Authorization: `Bearer ${authToken}`,
+            },
+          }
+        );
+        setChecks(res.data.data.checks);
+        setChecksCount(res.data.data.checksCount);
+      } catch (error) {
+        console.log(error);
+      }
+    };
+    fetchPage();
+  }, [
+    authToken,
+    monitorId,
+    filter,
+    paginationController.page,
+    paginationController.rowsPerPage,
+  ]);
+
+  const handlePageChange = (_, newPage) => {
+    setPaginationController({
+      ...paginationController,
+      page: newPage,
+    });
+  };
+
+  const handleChangeRowsPerPage = (event) => {
+    setPaginationController({
+      ...paginationController,
+      rowsPerPage: parseInt(event.target.value, 10),
+      page: 0,
+    });
+  };
+
+  return (
+    <TableContainer>
+      <Table>
+        <TableHead>
+          <TableRow>
+            <TableCell>Status</TableCell>
+            <TableCell>Date & Time</TableCell>
+            <TableCell>Message</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {checks.map((check) => {
+            const status = check.status === true ? "up" : "down";
+
+            return (
+              <TableRow key={check._id}>
+                <TableCell>
+                  <StatusLabel
+                    status={status}
+                    text={status}
+                    customStyles={{ textTransform: "capitalize" }}
+                  />
+                </TableCell>
+                <TableCell>
+                  {new Date(check.createdAt).toLocaleString()}
+                </TableCell>
+                <TableCell>{check.statusCode}</TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+        <TableFooter>
+          <TableRow>
+            <TablePagination
+              rowsPerPageOptions={[5, 10, 25]}
+              onPageChange={handlePageChange}
+              page={paginationController.page}
+              count={checksCount}
+              rowsPerPage={paginationController.rowsPerPage}
+              onRowsPerPageChange={handleChangeRowsPerPage}
+            />
+          </TableRow>
+        </TableFooter>
+      </Table>
+    </TableContainer>
+  );
+};
+
+PaginationTable.propTypes = {
+  monitorId: PropTypes.string.isRequired,
+  filter: PropTypes.string.isRequired,
+};
+
+export default PaginationTable;

--- a/Client/src/Pages/Monitors/Details/index.jsx
+++ b/Client/src/Pages/Monitors/Details/index.jsx
@@ -4,7 +4,6 @@ import { Box, Skeleton, Stack, Typography, useTheme } from "@mui/material";
 import { useSelector } from "react-redux";
 import { useNavigate, useParams } from "react-router-dom";
 import axiosInstance from "../../../Utils/axiosConfig";
-import BasicTable from "../../../Components/BasicTable";
 import MonitorDetailsAreaChart from "../../../Components/Charts/MonitorDetailsAreaChart";
 import { StatusLabel } from "../../../Components/Label";
 import ButtonGroup from "@mui/material/ButtonGroup";
@@ -13,6 +12,7 @@ import WestRoundedIcon from "@mui/icons-material/WestRounded";
 import GreenCheck from "../../../assets/icons/checkbox-green.svg?react";
 import RedCheck from "../../../assets/icons/checkbox-red.svg?react";
 import SettingsIcon from "../../../assets/icons/settings-bold.svg?react";
+import PaginationTable from "./PaginationTable";
 import {
   formatDuration,
   formatDurationRounded,
@@ -111,59 +111,10 @@ const SkeletonLayout = () => {
  */
 const DetailsPage = () => {
   const [monitor, setMonitor] = useState({});
-  const [data, setData] = useState({});
   const { monitorId } = useParams();
   const { authToken } = useSelector((state) => state.auth);
   const [filter, setFilter] = useState("day");
   const navigate = useNavigate();
-
-  const fetchDataForTable = useCallback(async () => {
-    try {
-      const res = await axiosInstance.get(
-        `/checks/${monitorId}?sortOrder=desc&filter=${filter}`,
-        {
-          headers: {
-            Authorization: `Bearer ${authToken}`,
-          },
-        }
-      );
-      const data = {
-        cols: [
-          { id: 1, name: "Status" },
-          { id: 2, name: "Date & Time" },
-          { id: 3, name: "Message" },
-        ],
-        rows: res.data.data.map((check, idx) => {
-          const status = check.status === true ? "up" : "down";
-
-          return {
-            id: check._id,
-            data: [
-              {
-                id: idx,
-                data: (
-                  <StatusLabel
-                    status={status}
-                    text={status}
-                    customStyles={{ textTransform: "capitalize" }}
-                  />
-                ),
-              },
-              {
-                id: idx + 1,
-                data: new Date(check.createdAt).toLocaleString(),
-              },
-              { id: idx + 2, data: check.statusCode },
-            ],
-          };
-        }),
-      };
-
-      setData(data);
-    } catch (error) {
-      console.log(error);
-    }
-  }, [authToken, monitorId, filter]);
 
   const fetchMonitor = useCallback(async () => {
     try {
@@ -185,10 +136,6 @@ const DetailsPage = () => {
   useEffect(() => {
     fetchMonitor();
   }, [fetchMonitor]);
-
-  useEffect(() => {
-    fetchDataForTable();
-  }, [fetchDataForTable]);
 
   const theme = useTheme();
 
@@ -390,7 +337,9 @@ const DetailsPage = () => {
             </Box>
             <Stack gap={theme.gap.ml}>
               <Typography component="h2">History</Typography>
-              <BasicTable data={data} paginated={true} reversed={true} />
+              {/* TODO New Table */}
+              <PaginationTable monitorId={monitorId} filter={filter} />
+              {/* <BasicTable data={data} paginated={true} /> */}
             </Stack>
           </Stack>
         </>

--- a/Client/src/Pages/Monitors/Details/index.jsx
+++ b/Client/src/Pages/Monitors/Details/index.jsx
@@ -119,10 +119,8 @@ const DetailsPage = () => {
 
   const fetchDataForTable = useCallback(async () => {
     try {
-      const limit = 0;
-
       const res = await axiosInstance.get(
-        `/monitors/${monitorId}?sortOrder=asc&limit=${limit}`,
+        `/checks/${monitorId}?sortOrder=desc&filter=${filter}`,
         {
           headers: {
             Authorization: `Bearer ${authToken}`,
@@ -135,7 +133,7 @@ const DetailsPage = () => {
           { id: 2, name: "Date & Time" },
           { id: 3, name: "Message" },
         ],
-        rows: res.data.data.checks.map((check, idx) => {
+        rows: res.data.data.map((check, idx) => {
           const status = check.status === true ? "up" : "down";
 
           return {
@@ -165,7 +163,7 @@ const DetailsPage = () => {
     } catch (error) {
       console.log(error);
     }
-  }, [authToken, monitorId]);
+  }, [authToken, monitorId, filter]);
 
   const fetchMonitor = useCallback(async () => {
     try {

--- a/Server/controllers/checkController.js
+++ b/Server/controllers/checkController.js
@@ -48,9 +48,12 @@ const getChecks = async (req, res, next) => {
 
   try {
     const checks = await req.db.getChecks(req);
-    return res
-      .status(200)
-      .json({ success: true, msg: successMessages.CHECK_GET, data: checks });
+    const checksCount = await req.db.getChecksCount(req);
+    return res.status(200).json({
+      success: true,
+      msg: successMessages.CHECK_GET,
+      data: { checksCount, checks },
+    });
   } catch (error) {
     error.service = SERVICE_NAME;
     next(error);

--- a/Server/controllers/checkController.js
+++ b/Server/controllers/checkController.js
@@ -2,6 +2,7 @@ const {
   createCheckParamValidation,
   createCheckBodyValidation,
   getChecksParamValidation,
+  getChecksQueryValidation,
   deleteChecksParamValidation,
 } = require("../validation/joi");
 const { successMessages } = require("../utils/messages");
@@ -35,6 +36,7 @@ const createCheck = async (req, res, next) => {
 const getChecks = async (req, res, next) => {
   try {
     await getChecksParamValidation.validateAsync(req.params);
+    await getChecksQueryValidation.validateAsync(req.query);
   } catch (error) {
     error.status = 422;
     error.service = SERVICE_NAME;
@@ -45,7 +47,7 @@ const getChecks = async (req, res, next) => {
   }
 
   try {
-    const checks = await req.db.getChecks(req.params.monitorId);
+    const checks = await req.db.getChecks(req);
     return res
       .status(200)
       .json({ success: true, msg: successMessages.CHECK_GET, data: checks });

--- a/Server/db/mongo/MongoDB.js
+++ b/Server/db/mongo/MongoDB.js
@@ -88,6 +88,7 @@ const {
 
 const {
   createCheck,
+  getChecksCount,
   getChecks,
   deleteChecks,
 } = require("./modules/checkModule");
@@ -145,6 +146,7 @@ module.exports = {
   deleteAllMonitors,
   editMonitor,
   createCheck,
+  getChecksCount,
   getChecks,
   deleteChecks,
   createAlert,

--- a/Server/utils/dataUtils.js
+++ b/Server/utils/dataUtils.js
@@ -19,7 +19,6 @@ const NormalizeData = (checks, rangeMin, rangeMax) => {
 
     const normalizedChecks = checks.map((check) => {
       const originalResponseTime = check.responseTime;
-      console.log(originalResponseTime);
       // Normalize the response time between 1 and 100
       let normalizedResponseTime =
         rangeMin +

--- a/Server/validation/joi.js
+++ b/Server/validation/joi.js
@@ -232,6 +232,12 @@ const getChecksParamValidation = joi.object({
   monitorId: joi.string().required(),
 });
 
+const getChecksQueryValidation = joi.object({
+  sortOrder: joi.string().valid("asc", "desc"),
+  limit: joi.number(),
+  filter: joi.string().valid("day", "week", "month"),
+});
+
 const deleteChecksParamValidation = joi.object({
   monitorId: joi.string().required(),
 });
@@ -311,6 +317,7 @@ module.exports = {
   createCheckParamValidation,
   createCheckBodyValidation,
   getChecksParamValidation,
+  getChecksQueryValidation,
   deleteChecksParamValidation,
   deleteUserParamValidation,
   getPageSpeedCheckParamValidation,

--- a/Server/validation/joi.js
+++ b/Server/validation/joi.js
@@ -236,6 +236,8 @@ const getChecksQueryValidation = joi.object({
   sortOrder: joi.string().valid("asc", "desc"),
   limit: joi.number(),
   filter: joi.string().valid("day", "week", "month"),
+  page: joi.number(),
+  rowsPerPage: joi.number(),
 });
 
 const deleteChecksParamValidation = joi.object({


### PR DESCRIPTION
Checks are now fetched from the Checks endpoint instead in a separate API calls

Checks are paginated, and only those needed are returned

I implemented a new table rarther than try to cram the more compled pagination logic into BasicTable, I don't think there are any real benefits to be reaped by trying to shoehorn the logic in.

@danielcj2 I'm affraid I'm once again going to have to ask you to style a table :joy:  Many thanks in advance :pray: 