### PR TITLE
Stop double rendering, add monitors to useEffect dependency array, #586

### DIFF
--- a/Client/src/Pages/Incidents/IncidentTable/index.jsx
+++ b/Client/src/Pages/Incidents/IncidentTable/index.jsx
@@ -30,6 +30,9 @@ const IncidentTable = ({ monitors, selectedMonitor, filter }) => {
 
   useEffect(() => {
     const fetchPage = async () => {
+      if (!monitors || Object.keys(monitors).length === 0) {
+        return;
+      }
       try {
         let url = `/checks/${selectedMonitor}?sortOrder=desc&filter=${filter}&page=${paginationController.page}&rowsPerPage=${paginationController.rowsPerPage}`;
 
@@ -52,6 +55,7 @@ const IncidentTable = ({ monitors, selectedMonitor, filter }) => {
   }, [
     authToken,
     user,
+    monitors,
     selectedMonitor,
     filter,
     paginationController.page,

--- a/Client/src/Pages/Incidents/index.jsx
+++ b/Client/src/Pages/Incidents/index.jsx
@@ -47,7 +47,6 @@ const Incidents = () => {
 
   useEffect(() => {
     const fetchMonitors = async () => {
-      console.log("fetching monitors");
       setLoading(true);
       const res = await axiosInstance.get(
         `/monitors/user/${authState.user._id}?status=false&limit=1`,

--- a/Client/src/Pages/Incidents/index.jsx
+++ b/Client/src/Pages/Incidents/index.jsx
@@ -47,6 +47,7 @@ const Incidents = () => {
 
   useEffect(() => {
     const fetchMonitors = async () => {
+      console.log("fetching monitors");
       setLoading(true);
       const res = await axiosInstance.get(
         `/monitors/user/${authState.user._id}?status=false&limit=1`,


### PR DESCRIPTION
There was a double rendering happening in `IncidentTable`, I've added a check condition to stop the extra rendering and fixed the depndency array as well.

I believe this resovles the skeleton issue, can you comfirm @danielcj2 ?