### PR TITLE
Added pagination resets, resolve #588

### DIFF
--- a/Client/src/Pages/Incidents/IncidentTable/index.jsx
+++ b/Client/src/Pages/Incidents/IncidentTable/index.jsx
@@ -29,6 +29,13 @@ const IncidentTable = ({ monitors, selectedMonitor, filter }) => {
   });
 
   useEffect(() => {
+    setPaginationController({
+      ...paginationController,
+      page: 0,
+    });
+  }, [filter, selectedMonitor]);
+
+  useEffect(() => {
     const fetchPage = async () => {
       if (!monitors || Object.keys(monitors).length === 0) {
         return;

--- a/Client/src/Pages/Monitors/Details/PaginationTable/index.jsx
+++ b/Client/src/Pages/Monitors/Details/PaginationTable/index.jsx
@@ -28,6 +28,13 @@ const PaginationTable = ({ monitorId, dateRange }) => {
   });
 
   useEffect(() => {
+    setPaginationController({
+      ...paginationController,
+      page: 0,
+    });
+  }, [dateRange]);
+
+  useEffect(() => {
     const fetchPage = async () => {
       try {
         const res = await axiosInstance.get(


### PR DESCRIPTION
- [x] Added `useEffect` with appropriate dependencies to reset pagination offset to `0` when a filter or monitor is selected
- [x] Fixes applied to both Incident table and Monitor details table 