### PR TITLE
chore: create openapi.json with openapi 3.1.0 format

### DIFF
--- a/Server/openapi.json
+++ b/Server/openapi.json
@@ -55,6 +55,45 @@
       "post": {
         "tags": ["auth"],
         "description": "Register a new user",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["firstName", "lastName", "email", "password", "role", "teamId"],
+                "properties": {
+                  "firstName": {
+                    "type": "string"
+                  },
+                  "lastName": {
+                    "type": "string"
+                  },
+                  "email": {
+                    "type": "string",
+                    "format": "email"
+                  },
+                  "password": {
+                    "type": "string",
+                    "format": "password"
+                  },
+                  "profileImage": {
+                    "type": "file",
+                    "format": "file"
+                  },
+                  "role": {
+                    "type": "array",
+                    "enum": [["user"], ["admin"], ["superadmin"]],
+                    "default": ["superadmin"]
+                  },
+                  "teamId": {
+                    "type": "string",
+                    "format": "uuid"
+                  }
+                }
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -93,6 +132,26 @@
       "post": {
         "tags": ["auth"],
         "description": "Login with credentials",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["email", "password"],
+                "properties": {
+                  "email": {
+                    "type": "string",
+                    "format": "email"
+                  },
+                  "password": {
+                    "type": "string",
+                    "format": "password"
+                  }
+                }
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",

--- a/Server/openapi.json
+++ b/Server/openapi.json
@@ -6,8 +6,8 @@
     "description": "BlueWave Uptime is an open source server monitoring application used to track the operational status and performance of servers and websites. It regularly checks whether a server/website is accessible and performs optimally, providing real-time alerts and reports on the monitored services' availability, downtime, and response time.",
     "contact": {
       "name": "API Support",
-      "url": "mailto:hello@bluewavelabs.ca",
-      "email": "hello@bluewavelabs.ca"
+      "url": "mailto:support@bluewavelabs.ca",
+      "email": "support@bluewavelabs.ca"
     },
     "license": {
       "name": "AGPLv3",

--- a/Server/openapi.json
+++ b/Server/openapi.json
@@ -602,8 +602,8 @@
           "profilePicUrl",
           "isActive",
           "isVerified",
-          "updated_at",
-          "created_at"
+          "updatedAt",
+          "createdAt"
         ],
         "properties": {
           "firstname": {
@@ -625,10 +625,10 @@
           "isVerified": {
             "type": "boolean"
           },
-          "updated_at": {
+          "updatedAt": {
             "type": "string"
           },
-          "created_at": {
+          "createdAt": {
             "type": "string"
           }
         }

--- a/Server/openapi.json
+++ b/Server/openapi.json
@@ -59,19 +59,31 @@
           "200": {
             "description": "OK",
             "content": {
-              "application/json": {}
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessResponse"
+                }
+              }
             }
           },
           "422": {
             "description": "Unprocessable Content",
             "content": {
-              "application/json": {}
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
             }
           },
           "500": {
             "description": "Internal Server Error",
             "content": {
-              "application/json": {}
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
             }
           }
         }
@@ -85,19 +97,31 @@
           "200": {
             "description": "OK",
             "content": {
-              "application/json": {}
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessResponse"
+                }
+              }
             }
           },
           "422": {
             "description": "Unprocessable Content",
             "content": {
-              "application/json": {}
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
             }
           },
           "500": {
             "description": "Internal Server Error",
             "content": {
-              "application/json": {}
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
             }
           }
         }
@@ -111,19 +135,31 @@
           "200": {
             "description": "OK",
             "content": {
-              "application/json": {}
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessResponse"
+                }
+              }
             }
           },
           "422": {
             "description": "Unprocessable Content",
             "content": {
-              "application/json": {}
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
             }
           },
           "500": {
             "description": "Internal Server Error",
             "content": {
-              "application/json": {}
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
             }
           }
         }
@@ -137,19 +173,31 @@
           "200": {
             "description": "OK",
             "content": {
-              "application/json": {}
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessResponse"
+                }
+              }
             }
           },
           "422": {
             "description": "Unprocessable Content",
             "content": {
-              "application/json": {}
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
             }
           },
           "500": {
             "description": "Internal Server Error",
             "content": {
-              "application/json": {}
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
             }
           }
         }
@@ -161,19 +209,31 @@
           "200": {
             "description": "OK",
             "content": {
-              "application/json": {}
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessResponse"
+                }
+              }
             }
           },
           "422": {
             "description": "Unprocessable Content",
             "content": {
-              "application/json": {}
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
             }
           },
           "500": {
             "description": "Internal Server Error",
             "content": {
-              "application/json": {}
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
             }
           }
         }
@@ -187,19 +247,31 @@
           "200": {
             "description": "OK",
             "content": {
-              "application/json": {}
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessResponse"
+                }
+              }
             }
           },
           "422": {
             "description": "Unprocessable Content",
             "content": {
-              "application/json": {}
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
             }
           },
           "500": {
             "description": "Internal Server Error",
             "content": {
-              "application/json": {}
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
             }
           }
         }
@@ -213,19 +285,31 @@
           "200": {
             "description": "OK",
             "content": {
-              "application/json": {}
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessResponse"
+                }
+              }
             }
           },
           "422": {
             "description": "Unprocessable Content",
             "content": {
-              "application/json": {}
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
             }
           },
           "500": {
             "description": "Internal Server Error",
             "content": {
-              "application/json": {}
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
             }
           }
         }
@@ -239,19 +323,31 @@
           "200": {
             "description": "OK",
             "content": {
-              "application/json": {}
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessResponse"
+                }
+              }
             }
           },
           "422": {
             "description": "Unprocessable Content",
             "content": {
-              "application/json": {}
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
             }
           },
           "500": {
             "description": "Internal Server Error",
             "content": {
-              "application/json": {}
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
             }
           }
         }
@@ -265,19 +361,31 @@
           "200": {
             "description": "OK",
             "content": {
-              "application/json": {}
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessResponse"
+                }
+              }
             }
           },
           "422": {
             "description": "Unprocessable Content",
             "content": {
-              "application/json": {}
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
             }
           },
           "500": {
             "description": "Internal Server Error",
             "content": {
-              "application/json": {}
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
             }
           }
         }
@@ -291,19 +399,31 @@
           "200": {
             "description": "OK",
             "content": {
-              "application/json": {}
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessResponse"
+                }
+              }
             }
           },
           "422": {
             "description": "Unprocessable Content",
             "content": {
-              "application/json": {}
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
             }
           },
           "500": {
             "description": "Internal Server Error",
             "content": {
-              "application/json": {}
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
             }
           }
         }
@@ -317,19 +437,31 @@
           "200": {
             "description": "OK",
             "content": {
-              "application/json": {}
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessResponse"
+                }
+              }
             }
           },
           "422": {
             "description": "Unprocessable Content",
             "content": {
-              "application/json": {}
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
             }
           },
           "500": {
             "description": "Internal Server Error",
             "content": {
-              "application/json": {}
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
             }
           }
         }
@@ -343,20 +475,61 @@
           "200": {
             "description": "OK",
             "content": {
-              "application/json": {}
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessResponse"
+                }
+              }
             }
           },
           "422": {
             "description": "Unprocessable Content",
             "content": {
-              "application/json": {}
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
             }
           },
           "500": {
             "description": "Internal Server Error",
             "content": {
-              "application/json": {}
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
             }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ErrorResponse": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "msg": {
+            "type": "string"
+          }
+        }
+      },
+      "SuccessResponse": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "msg": {
+            "type": "string"
+          },
+          "data": {
+            "type": "object"
           }
         }
       }

--- a/Server/openapi.json
+++ b/Server/openapi.json
@@ -43,5 +43,323 @@
         }
       }
     }
-  ]
+  ],
+  "tags": [
+    {
+      "name": "auth",
+      "description": "Authentication"
+    }
+  ],
+  "paths": {
+    "/auth/register": {
+      "post": {
+        "tags": ["auth"],
+        "description": "Register a new user",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {}
+            }
+          },
+          "422": {
+            "description": "Unprocessable Content",
+            "content": {
+              "application/json": {}
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {}
+            }
+          }
+        }
+      }
+    },
+    "/auth/login": {
+      "post": {
+        "tags": ["auth"],
+        "description": "Login with credentials",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {}
+            }
+          },
+          "422": {
+            "description": "Unprocessable Content",
+            "content": {
+              "application/json": {}
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {}
+            }
+          }
+        }
+      }
+    },
+    "/auth/logout": {
+      "post": {
+        "tags": ["auth"],
+        "description": "Logout",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {}
+            }
+          },
+          "422": {
+            "description": "Unprocessable Content",
+            "content": {
+              "application/json": {}
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {}
+            }
+          }
+        }
+      }
+    },
+    "/auth/user/:userId": {
+      "put": {
+        "tags": ["auth"],
+        "description": "Change user informations",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {}
+            }
+          },
+          "422": {
+            "description": "Unprocessable Content",
+            "content": {
+              "application/json": {}
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {}
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": ["auth"],
+        "description": "Delete user",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {}
+            }
+          },
+          "422": {
+            "description": "Unprocessable Content",
+            "content": {
+              "application/json": {}
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {}
+            }
+          }
+        }
+      }
+    },
+    "/auth/users/admin": {
+      "get": {
+        "tags": ["auth"],
+        "description": "Checks to see if an admin account exists",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {}
+            }
+          },
+          "422": {
+            "description": "Unprocessable Content",
+            "content": {
+              "application/json": {}
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {}
+            }
+          }
+        }
+      }
+    },
+    "/auth/users": {
+      "get": {
+        "tags": ["auth"],
+        "description": "Get all users",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {}
+            }
+          },
+          "422": {
+            "description": "Unprocessable Content",
+            "content": {
+              "application/json": {}
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {}
+            }
+          }
+        }
+      }
+    },
+    "/auth/invite": {
+      "post": {
+        "tags": ["auth"],
+        "description": "Invite people to application",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {}
+            }
+          },
+          "422": {
+            "description": "Unprocessable Content",
+            "content": {
+              "application/json": {}
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {}
+            }
+          }
+        }
+      }
+    },
+    "/auth/invite/verify": {
+      "post": {
+        "tags": ["auth"],
+        "description": "Verify the invite",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {}
+            }
+          },
+          "422": {
+            "description": "Unprocessable Content",
+            "content": {
+              "application/json": {}
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {}
+            }
+          }
+        }
+      }
+    },
+    "/auth/recovery/request": {
+      "post": {
+        "tags": ["auth"],
+        "description": "Request a recovery token",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {}
+            }
+          },
+          "422": {
+            "description": "Unprocessable Content",
+            "content": {
+              "application/json": {}
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {}
+            }
+          }
+        }
+      }
+    },
+    "/auth/recovery/validate": {
+      "post": {
+        "tags": ["auth"],
+        "description": "Validate recovery token",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {}
+            }
+          },
+          "422": {
+            "description": "Unprocessable Content",
+            "content": {
+              "application/json": {}
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {}
+            }
+          }
+        }
+      }
+    },
+    "/auth/recovery/reset": {
+      "post": {
+        "tags": ["auth"],
+        "description": "Password reset",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {}
+            }
+          },
+          "422": {
+            "description": "Unprocessable Content",
+            "content": {
+              "application/json": {}
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {}
+            }
+          }
+        }
+      }
+    }
+  }
 }

--- a/Server/openapi.json
+++ b/Server/openapi.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.1.0",
   "info": {
-    "title": "BluWave Uptime",
+    "title": "BlueWave Uptime",
     "summary": "BlueWave Uptime OpenAPI Specifications",
     "description": "BlueWave Uptime is an open source server monitoring application used to track the operational status and performance of servers and websites. It regularly checks whether a server/website is accessible and performs optimally, providing real-time alerts and reports on the monitored services' availability, downtime, and response time.",
     "contact": {

--- a/Server/openapi.json
+++ b/Server/openapi.json
@@ -37,6 +37,38 @@
     {
       "name": "auth",
       "description": "Authentication"
+    },
+    {
+      "name": "invite",
+      "description": "Invite"
+    },
+    {
+      "name": "monitors",
+      "description": "Monitors"
+    },
+    {
+      "name": "checks",
+      "description": "Checks"
+    },
+    {
+      "name": "alerts",
+      "description": "Alerts"
+    },
+    {
+      "name": "pagespeed",
+      "description": "Page Speed"
+    },
+    {
+      "name": "maintenance-window",
+      "description": "Maintenance window"
+    },
+    {
+      "name": "healthy",
+      "description": "Health check"
+    },
+    {
+      "name": "mail",
+      "description": "Mail service"
     }
   ],
   "paths": {

--- a/Server/openapi.json
+++ b/Server/openapi.json
@@ -186,44 +186,6 @@
         }
       }
     },
-    "/auth/logout": {
-      "post": {
-        "tags": ["auth"],
-        "description": "Logout",
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UserSuccessResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Unprocessable Content",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/auth/user/:userId": {
       "put": {
         "tags": ["auth"],

--- a/Server/openapi.json
+++ b/Server/openapi.json
@@ -61,7 +61,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SuccessResponse"
+                  "$ref": "#/components/schemas/UserSuccessResponse"
                 }
               }
             }
@@ -99,7 +99,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SuccessResponse"
+                  "$ref": "#/components/schemas/UserSuccessResponse"
                 }
               }
             }
@@ -137,7 +137,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SuccessResponse"
+                  "$ref": "#/components/schemas/UserSuccessResponse"
                 }
               }
             }
@@ -175,7 +175,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SuccessResponse"
+                  "$ref": "#/components/schemas/UserSuccessResponse"
                 }
               }
             }
@@ -211,7 +211,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SuccessResponse"
+                  "$ref": "#/components/schemas/UserSuccessResponse"
                 }
               }
             }
@@ -249,7 +249,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SuccessResponse"
+                  "$ref": "#/components/schemas/UserSuccessResponse"
                 }
               }
             }
@@ -287,7 +287,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SuccessResponse"
+                  "$ref": "#/components/schemas/UserSuccessResponse"
                 }
               }
             }
@@ -325,7 +325,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SuccessResponse"
+                  "$ref": "#/components/schemas/UserSuccessResponse"
                 }
               }
             }
@@ -363,7 +363,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SuccessResponse"
+                  "$ref": "#/components/schemas/UserSuccessResponse"
                 }
               }
             }
@@ -401,7 +401,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SuccessResponse"
+                  "$ref": "#/components/schemas/UserSuccessResponse"
                 }
               }
             }
@@ -439,7 +439,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SuccessResponse"
+                  "$ref": "#/components/schemas/UserSuccessResponse"
                 }
               }
             }
@@ -477,7 +477,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SuccessResponse"
+                  "$ref": "#/components/schemas/UserSuccessResponse"
                 }
               }
             }
@@ -530,6 +530,223 @@
           },
           "data": {
             "type": "object"
+          }
+        }
+      },
+      "UserSuccessResponse": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "msg": {
+            "type": "string"
+          },
+          "data": {
+            "type": "object",
+            "$ref": "#/components/schemas/UserDataType"
+          }
+        }
+      },
+      "MonitorSuccessResponse": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "msg": {
+            "type": "string"
+          },
+          "data": {
+            "type": "object",
+            "$ref": "#/components/schemas/MonitorDataType"
+          }
+        }
+      },
+      "CheckDataSuccessResponse": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "msg": {
+            "type": "string"
+          },
+          "data": {
+            "type": "object",
+            "$ref": "#/components/schemas/CheckDataType"
+          }
+        }
+      },
+      "AlertDataSuccessResponse": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "msg": {
+            "type": "string"
+          },
+          "data": {
+            "type": "object",
+            "$ref": "#/components/schemas/AlertDataType"
+          }
+        }
+      },
+      "UserDataType": {
+        "type": "object",
+        "required": [
+          "firstname",
+          "lastname",
+          "email",
+          "profilePicUrl",
+          "isActive",
+          "isVerified",
+          "updated_at",
+          "created_at"
+        ],
+        "properties": {
+          "firstname": {
+            "type": "string"
+          },
+          "lastname": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string",
+            "format": "email"
+          },
+          "profilePicUrl": {
+            "type": "string"
+          },
+          "isActive": {
+            "type": "boolean"
+          },
+          "isVerified": {
+            "type": "boolean"
+          },
+          "updated_at": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string"
+          }
+        }
+      },
+      "MonitorDataType": {
+        "type": "object",
+        "required": [
+          "userId",
+          "name",
+          "description",
+          "url",
+          "isActive",
+          "interval",
+          "updatedAt",
+          "createdAt"
+        ],
+        "properties": {
+          "userId": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
+          "isActive": {
+            "type": "boolean"
+          },
+          "interval": {
+            "type": "integer"
+          },
+          "updatedAt": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string"
+          }
+        }
+      },
+      "CheckDataType": {
+        "type": "object",
+        "required": [
+          "monitorId",
+          "status",
+          "responseTime",
+          "statusCode",
+          "message",
+          "updatedAt",
+          "createdAt"
+        ],
+        "properties": {
+          "monitorId": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "responseTime": {
+            "type": "integer"
+          },
+          "statusCode": {
+            "type": "integer"
+          },
+          "message": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string"
+          }
+        }
+      },
+      "AlertDataType": {
+        "type": "object",
+        "required": [
+          "checkId",
+          "monitorId",
+          "userId",
+          "status",
+          "message",
+          "notifiedStatus",
+          "acknowledgedStatus",
+          "updatedAt",
+          "createdAt"
+        ],
+        "properties": {
+          "checkId": {
+            "type": "string"
+          },
+          "monitorId": {
+            "type": "string"
+          },
+          "userId": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "notifiedStatus": {
+            "type": "boolean"
+          },
+          "acknowledgedStatus": {
+            "type": "boolean"
+          },
+          "updatedAt": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string"
           }
         }
       }

--- a/Server/openapi.json
+++ b/Server/openapi.json
@@ -17,17 +17,6 @@
   },
   "servers": [
     {
-      "url": "https://bluewavelabs.ca/{API_PATH}",
-      "description": "Remote Development Server",
-      "variables": {
-        "API_PATH": {
-          "description": "API Base Path",
-          "enum": ["api/v1", "api/v1.1", "api/v2"],
-          "default": "api/v1"
-        }
-      }
-    },
-    {
       "url": "http://localhost:{PORT}/{API_PATH}",
       "description": "Local Development Server",
       "variables": {

--- a/Server/openapi.json
+++ b/Server/openapi.json
@@ -1,0 +1,35 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "BluWave Uptime",
+    "summary": "BlueWave Uptime OpenAPI Specifications",
+    "description": "BlueWave Uptime is an open source server monitoring application used to track the operational status and performance of servers and websites. It regularly checks whether a server/website is accessible and performs optimally, providing real-time alerts and reports on the monitored services' availability, downtime, and response time.",
+    "contact": {
+      "name": "API Support",
+      "url": "mailto:hello@bluewavelabs.ca",
+      "email": "hello@bluewavelabs.ca"
+    },
+    "license": {
+      "name": "AGPLv3",
+      "url": "https://github.com/bluewave-labs/bluewave-uptime/tree/HEAD/LICENSE"
+    },
+    "version": "1.0"
+  },
+  "servers": [
+    {
+      "url": "https://bluewavelabs.ca",
+      "description": "Remote Development Server"
+    },
+    {
+      "url": "http://localhost:{PORT}",
+      "description": "Local Development Server",
+      "variables": {
+        "PORT": {
+          "description": "The Data Set API is accessible via https and http",
+          "enum": ["5000", "3000", "8080"],
+          "default": "5000"
+        }
+      }
+    }
+  ]
+}

--- a/Server/openapi.json
+++ b/Server/openapi.json
@@ -17,17 +17,29 @@
   },
   "servers": [
     {
-      "url": "https://bluewavelabs.ca",
-      "description": "Remote Development Server"
+      "url": "https://bluewavelabs.ca/{API_PATH}",
+      "description": "Remote Development Server",
+      "variables": {
+        "API_PATH": {
+          "description": "API Base Path",
+          "enum": ["api/v1", "api/v1.1", "api/v2"],
+          "default": "api/v1"
+        }
+      }
     },
     {
-      "url": "http://localhost:{PORT}",
+      "url": "http://localhost:{PORT}/{API_PATH}",
       "description": "Local Development Server",
       "variables": {
         "PORT": {
-          "description": "The Data Set API is accessible via https and http",
+          "description": "API Port",
           "enum": ["5000", "3000", "8080"],
           "default": "5000"
+        },
+        "API_PATH": {
+          "description": "API Base Path",
+          "enum": ["api/v1", "api/v1.1", "api/v2"],
+          "default": "api/v1"
         }
       }
     }

--- a/Server/openapi.json
+++ b/Server/openapi.json
@@ -546,6 +546,44 @@
           }
         }
       }
+    },
+    "/healthy": {
+      "get": {
+        "tags": ["healthy"],
+        "description": "Health check",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {


### PR DESCRIPTION
Create `openapi.json` under the Server directory. Yaml is easy to read and write for me but to make it compatible with **SwaggerHub** and **SwaggerUIExpress** I choose the json.

```js
const openapi = require("./openapi.json")
```

It's not a complete fix but still associated with #581 

## To Do List
- [x] info
  - [x] title, summary, description
  - [x] contact
  - [x] version
- [x] servers
  - [x] local development server
- [x] tags(route groups) 
- [ ] paths
  - [x] /auth/register
  - [x] /auth/login
  - [ ] ...
  - [x] /healthy