### PR TITLE
Use alpine node for Docker images

### DIFF
--- a/Docker/client.Dockerfile
+++ b/Docker/client.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20
+FROM node:20-alpine
 
 WORKDIR /app
 

--- a/Docker/server.Dockerfile
+++ b/Docker/server.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20
+FROM node:20-alpine
 
 WORKDIR /app
 


### PR DESCRIPTION
Node docker images are based on a full featured Debian distro, as such they take up a lot of space (1.2gb each)

If we use the Node image based on the Alpine distro instead we can save quite a bit of space (and memory) as we don't need all the Debian features.