### PR TITLE
Add null monitor check to Network Service

### DIFF
--- a/Server/service/networkService.js
+++ b/Server/service/networkService.js
@@ -16,6 +16,14 @@ class NetworkService {
   async handleNotification(job, isAlive) {
     const { _id } = job.data;
     const monitor = await this.db.getMonitorById(_id);
+    if (monitor === null || monitor === undefined) {
+      logger.error(`Null Monitor: ${_id}`, {
+        method: "handleNotification",
+        service: this.SERVICE_NAME,
+        jobId: job.id,
+      });
+      return;
+    }
 
     // If monitor status changes, update monitor status and send notification
     if (monitor.status !== isAlive) {


### PR DESCRIPTION
- [x] Add null monitor check to `NetworkService`.  

If a job is left in the queue for some reason and it's associated monitor is deleted then `null` will be returned when a monitor is queried.  

Adding null check allows for graceful failure here