### PR TITLE
Add safe accesss default for rowsPerPage, add proptypes

### DIFF
--- a/Client/src/Components/BasicTable/index.jsx
+++ b/Client/src/Components/BasicTable/index.jsx
@@ -15,7 +15,7 @@ import {
   Stack,
 } from "@mui/material";
 import { useDispatch, useSelector } from "react-redux";
-import { useLocation, useParams } from "react-router-dom";
+import { useLocation } from "react-router-dom";
 import { setRowsPerPage } from "../../Features/UI/uiSlice";
 import LeftArrowDouble from "../../assets/icons/left-arrow-double.svg?react";
 import RightArrowDouble from "../../assets/icons/right-arrow-double.svg?react";
@@ -90,6 +90,13 @@ const TablePaginationActions = (props) => {
   );
 };
 
+TablePaginationActions.propTypes = {
+  count: PropTypes.number.isRequired,
+  page: PropTypes.number.isRequired,
+  rowsPerPage: PropTypes.number.isRequired,
+  onPageChange: PropTypes.func.isRequired,
+};
+
 /**
  * BasicTable Component
  * Renders a table with optional pagination.
@@ -144,12 +151,13 @@ const TablePaginationActions = (props) => {
  */
 
 const BasicTable = ({ data, paginated, reversed }) => {
+  const DEFAULT_ROWS_PER_PAGE = 5;
   const theme = useTheme();
   const location = useLocation();
   const dispatch = useDispatch();
   const uiState = useSelector((state) => state.ui);
   let table = location.pathname.split("/").pop();
-  let rowsPerPage = uiState[table].rowsPerPage;
+  let rowsPerPage = uiState?.[table]?.rowsPerPage ?? DEFAULT_ROWS_PER_PAGE;
   const [page, setPage] = useState(0);
 
   useEffect(() => {


### PR DESCRIPTION
This PR fixes some minor issues with the `BasicTable` component

- [x] Add safety to property access
- [x] Add prop types to sub component 