### PR TITLE
Add table prop to BasicTable to specify table name, resolves #707

### DIFF
--- a/Client/src/Components/BasicTable/index.jsx
+++ b/Client/src/Components/BasicTable/index.jsx
@@ -15,7 +15,6 @@ import {
   Stack,
 } from "@mui/material";
 import { useDispatch, useSelector } from "react-redux";
-import { useLocation } from "react-router-dom";
 import { setRowsPerPage } from "../../Features/UI/uiSlice";
 import LeftArrowDouble from "../../assets/icons/left-arrow-double.svg?react";
 import RightArrowDouble from "../../assets/icons/right-arrow-double.svg?react";
@@ -150,13 +149,11 @@ TablePaginationActions.propTypes = {
  * <BasicTable data={data} rows={rows} paginated={true} />
  */
 
-const BasicTable = ({ data, paginated, reversed }) => {
+const BasicTable = ({ data, paginated, reversed, table }) => {
   const DEFAULT_ROWS_PER_PAGE = 5;
   const theme = useTheme();
-  const location = useLocation();
   const dispatch = useDispatch();
   const uiState = useSelector((state) => state.ui);
-  let table = location.pathname.split("/").pop();
   let rowsPerPage = uiState?.[table]?.rowsPerPage ?? DEFAULT_ROWS_PER_PAGE;
   const [page, setPage] = useState(0);
 
@@ -293,6 +290,7 @@ BasicTable.propTypes = {
   paginated: PropTypes.bool,
   reversed: PropTypes.bool,
   rowPerPage: PropTypes.number,
+  table: PropTypes.string,
 };
 
 export default BasicTable;

--- a/Client/src/Components/TabPanels/Account/TeamPanel.jsx
+++ b/Client/src/Components/TabPanels/Account/TeamPanel.jsx
@@ -294,7 +294,12 @@ const TeamPanel = () => {
             onClick={() => setIsOpen(true)}
           />
         </Stack>
-        <BasicTable data={tableData} paginated={false} reversed={true} />
+        <BasicTable
+          data={tableData}
+          paginated={false}
+          reversed={true}
+          table={"team"}
+        />
       </Stack>
       <Modal
         aria-labelledby="modal-invite-member"

--- a/Client/src/Pages/Monitors/Details/index.jsx
+++ b/Client/src/Pages/Monitors/Details/index.jsx
@@ -330,9 +330,7 @@ const DetailsPage = () => {
             </Box>
             <Stack gap={theme.gap.ml}>
               <Typography component="h2">History</Typography>
-              {/* TODO New Table */}
               <PaginationTable monitorId={monitorId} dateRange={dateRange} />
-              {/* <BasicTable data={data} paginated={true} /> */}
             </Stack>
           </Stack>
         </>

--- a/Client/src/Pages/Monitors/index.jsx
+++ b/Client/src/Pages/Monitors/index.jsx
@@ -452,7 +452,7 @@ const Monitors = () => {
                   </Box>
                   {/* TODO - add search bar */}
                 </Stack>
-                <BasicTable data={data} paginated={true} />
+                <BasicTable data={data} paginated={true} table={"monitors"} />
               </Box>
             </>
           )}


### PR DESCRIPTION
This PR resolves the bug with `rowsPerPage` in the UI state being set using the path.

- [x] BasicTable takes a `table` prop that specifies which table is being displayed
- [x] UI state is updated using this identifier 