### PR TITLE
Add safety check for monitor

### DIFF
--- a/Server/db/mongo/modules/monitorModule.js
+++ b/Server/db/mongo/modules/monitorModule.js
@@ -280,6 +280,9 @@ const getMonitorStatsById = async (req) => {
 const getMonitorById = async (monitorId) => {
   try {
     const monitor = await Monitor.findById(monitorId);
+    if (monitor === null || monitor === undefined) {
+      throw new Error(errorMessages.DB_FIND_MONTIOR_BY_ID(monitorId));
+    }
     // Get notifications
     const notifications = await Notification.find({
       monitorId: monitorId,

--- a/Server/index.js
+++ b/Server/index.js
@@ -140,9 +140,9 @@ const startApp = async () => {
     }
     process.exit(0);
   };
-  process.on("SIGUSR2", cleanup);
-  process.on("SIGINT", cleanup);
-  process.on("SIGTERM", cleanup);
+  // process.on("SIGUSR2", cleanup);
+  // process.on("SIGINT", cleanup);
+  // process.on("SIGTERM", cleanup);
 };
 
 startApp().catch((error) => {

--- a/Server/index.js
+++ b/Server/index.js
@@ -140,9 +140,9 @@ const startApp = async () => {
     }
     process.exit(0);
   };
-  // process.on("SIGUSR2", cleanup);
-  // process.on("SIGINT", cleanup);
-  // process.on("SIGTERM", cleanup);
+  process.on("SIGUSR2", cleanup);
+  process.on("SIGINT", cleanup);
+  process.on("SIGTERM", cleanup);
 };
 
 startApp().catch((error) => {


### PR DESCRIPTION
This PR fixes unsafe access to a `monitor`'s `notification` field.

The issue presents itself if there is a discrepancy beween the job in the Redis database and the data in the Mogno dataabse.

- [x] Add null and undefined check to `getMonitorByid()`
- [x] Add missing try/catch block to `handleNotifications()` method