### PR TITLE
fix host proptypes

### DIFF
--- a/Client/src/Pages/Monitors/Home/host.jsx
+++ b/Client/src/Pages/Monitors/Home/host.jsx
@@ -53,7 +53,8 @@ Host.propTypes = {
   params: PropTypes.shape({
     title: PropTypes.string,
     percentageColor: PropTypes.string,
-    percentage: PropTypes.number,
+    percentage: PropTypes.string,
+    url: PropTypes.string,
   }).isRequired,
 };
 


### PR DESCRIPTION
This PR udpates host proptypes as the `percentage` prop has changed from `number` to `string` with the implementation of uptime percentage.

- [x]  Add prop type for `param.url`
- [x]  Update prop type for `percentage` 