### PR TITLE
Add check for monitor active state before adding jobs to queue on sta…

### DIFF
--- a/Server/service/jobQueue.js
+++ b/Server/service/jobQueue.js
@@ -39,7 +39,9 @@ class JobQueue {
       queue.networkService = networkService;
       const monitors = await db.getAllMonitors();
       for (const monitor of monitors) {
-        await queue.addJob(monitor.id, monitor);
+        if (monitor.active) {
+          await queue.addJob(monitor.id, monitor);
+        }
       }
       const workerStats = await queue.getWorkerStats();
       await queue.scaleWorkers(workerStats);


### PR DESCRIPTION
This PR resolves the monitor pause state bug

When the server is started, all monitors were added to the JobQueue regardless of active status. 

- [x] Check if monitor is active before adding it to the job queue