### PR TITLE
Add env files, update config

### DIFF
--- a/Docker/docker-compose.yaml
+++ b/Docker/docker-compose.yaml
@@ -33,8 +33,11 @@ services:
       - ./redis/data:/data
   mongodb:
     image: uptime_database_mongo:latest
-    command: ["mongod", "--quiet"]
+    command: ["mongod", "--quiet", "--auth"]
     ports:
       - "27017:27017"
     volumes:
       - ./mongo/data:/data/db
+      - ./mongo/init/create_users.js:/docker-entrypoint-initdb.d/create_users.js
+    env_file:
+      - mongo.env

--- a/Docker/mongo/init/create_users.js
+++ b/Docker/mongo/init/create_users.js
@@ -1,0 +1,16 @@
+var username = process.env.USERNAME_ENV_VAR;
+var password = process.env.PASSWORD_ENV_VAR;
+
+db = db.getSiblingDB("uptime_db");
+
+db.createUser({
+  user: username,
+  pwd: password,
+  roles: [
+    {
+      role: "readWrite",
+      db: "uptime_db",
+    },
+  ],
+});
+print("User uptime_user created successfully");

--- a/Docker/mongoDB.Dockerfile
+++ b/Docker/mongoDB.Dockerfile
@@ -1,3 +1,3 @@
 FROM mongo
 EXPOSE 27017
-CMD ["mongod", "--auth"]
+CMD ["mongod"]

--- a/Docker/mongoDB.Dockerfile
+++ b/Docker/mongoDB.Dockerfile
@@ -1,2 +1,3 @@
 FROM mongo
 EXPOSE 27017
+CMD ["mongod", "--auth"]

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ To get the application up and running you need to:
 CLIENT_HOST="http://localhost:5173"
 JWT_SECRET=<jwt_secret>
 DB_TYPE="MongoDB"
-DB_CONNECTION_STRING="mongodb://mongodb:27017/uptime_db"
+DB_CONNECTION_STRING="mongodb://<username>:<password>@mongodb:27017/uptime_db"
 REDIS_HOST="redis"
 REDIS_PORT=6379
 TOKEN_TTL="99d"
@@ -192,6 +192,13 @@ SYSTEM_EMAIL_PASSWORD=<system_email_password>
 ```
 VITE_APP_API_BASE_URL="http://localhost:5000/api/v1"
 VITE_APP_API_LOG_LEVEL="debug"
+```
+
+3.  In the `Dokcer` directory create a `mongo.env` file with a username and password:
+
+```
+USERNAME_ENV_VAR=user
+PASSWORD_ENV_VAR=password
 ```
 
 4.  In the `Docker` directory run `docker compose up` to run the `docker-compose.yaml` file and start all four images.

--- a/README.md
+++ b/README.md
@@ -170,7 +170,15 @@ The fastest way to start the application is to use our Dockerfiles and [Docker C
 To get the application up and running you need to:
 
 1. In the `Docker` directory run the build script `build_images.sh` to build docker images for the client, server, Redis database, and MongoDB database.
-2. In the `Docker` directory, create a `server.env` file with the [requried environtmental variables](#env-vars-server) for the server. Sample file:
+
+2. In the `Dokcer` directory create a `mongo.env` file with a username and password:
+
+```
+USERNAME_ENV_VAR=user
+PASSWORD_ENV_VAR=password
+```
+
+3. In the `Docker` directory, create a `server.env` file with the [requried environtmental variables](#env-vars-server) for the server. Sample file:
 
 ```
 CLIENT_HOST="http://localhost:5173"
@@ -187,21 +195,14 @@ SYSTEM_EMAIL_ADDRESS=<system_email>
 SYSTEM_EMAIL_PASSWORD=<system_email_password>
 ```
 
-3.  In the `Client` directory, create a `client.env` file with the [required environtmental variables](#env-vars-client) for the client. Sample file:
+4.  In the `Client` directory, create a `client.env` file with the [required environtmental variables](#env-vars-client) for the client. Sample file:
 
 ```
 VITE_APP_API_BASE_URL="http://localhost:5000/api/v1"
 VITE_APP_API_LOG_LEVEL="debug"
 ```
 
-3.  In the `Dokcer` directory create a `mongo.env` file with a username and password:
-
-```
-USERNAME_ENV_VAR=user
-PASSWORD_ENV_VAR=password
-```
-
-4.  In the `Docker` directory run `docker compose up` to run the `docker-compose.yaml` file and start all four images.
+5.  In the `Docker` directory run `docker compose up` to run the `docker-compose.yaml` file and start all four images.
 
 That's it, the application is ready to use on port 80.
 <br/>


### PR DESCRIPTION
This PR addresses lack of security for MongoDB, revealed by recent ransom request

- [x] Add "--auth" flag to docker compose 
- [x] Add a config script to create a user on DB spinup
- [x] Mount script to docker entry point

This shouldn't affect developers on their local development instances, only those that are deployed using docker compose