### PR TITLE
Enabled incident in actions menu, set selected monitor in Incidents page

### DIFF
--- a/Client/src/App.jsx
+++ b/Client/src/App.jsx
@@ -71,7 +71,7 @@ function App() {
             element={<ProtectedRoute Component={Configure} />}
           />
           <Route
-            path="incidents"
+            path="incidents/:monitorId?"
             element={<ProtectedRoute Component={Incidents} />}
           />
 

--- a/Client/src/Pages/Incidents/index.jsx
+++ b/Client/src/Pages/Incidents/index.jsx
@@ -1,6 +1,8 @@
 import { useState, useEffect } from "react";
 import { useSelector } from "react-redux";
 import { ButtonGroup, Stack, Typography, Button } from "@mui/material";
+import { useParams } from "react-router-dom";
+
 import { networkService } from "../../main";
 import { useTheme } from "@emotion/react";
 import Select from "../../Components/Inputs/Select";
@@ -11,6 +13,7 @@ import SkeletonLayout from "./skeleton";
 const Incidents = () => {
   const theme = useTheme();
   const authState = useSelector((state) => state.auth);
+  const { monitorId } = useParams();
 
   const [monitors, setMonitors] = useState({});
   const [selectedMonitor, setSelectedMonitor] = useState("0");
@@ -40,6 +43,7 @@ const Incidents = () => {
           return acc;
         }, {});
         setMonitors(monitorLookup);
+        monitorId !== undefined && setSelectedMonitor(monitorId);
       }
       setLoading(false);
     };

--- a/Client/src/Pages/Monitors/Home/actionsMenu.jsx
+++ b/Client/src/Pages/Monitors/Home/actionsMenu.jsx
@@ -125,7 +125,14 @@ const ActionsMenu = ({ monitor, isAdmin, updateCallback }) => {
           Details
         </MenuItem>
         {/* TODO - pass monitor id to Incidents page */}
-        <MenuItem disabled>Incidents</MenuItem>
+        <MenuItem
+          onClick={(e) => {
+            e.stopPropagation();
+            navigate(`/incidents/${actions.id}`);
+          }}
+        >
+          Incidents
+        </MenuItem>
         {isAdmin && (
           <MenuItem
             onClick={(e) => {


### PR DESCRIPTION
This PR enables the "Incidents" action menu item

- [x] Enable incident button
- [x] Add optional `monitorId` parameter to Incidents route
- [x] Set selected monitor on incidents page if a `monitorId` is present  