### PR TITLE
Remove checks from monitor query

### DIFF
--- a/Client/src/Pages/Incidents/index.jsx
+++ b/Client/src/Pages/Incidents/index.jsx
@@ -28,7 +28,7 @@ const Incidents = () => {
       const res = await networkService.getMonitorsByTeamId(
         authState.authToken,
         authState.user.teamId,
-        1,
+        -1,
         null,
         null,
         null,
@@ -36,6 +36,7 @@ const Incidents = () => {
         null,
         null
       );
+      console.log(res.data.data);
       // Reduce to a lookup object for 0(1) lookup
       if (res?.data?.data?.monitors?.length > 0) {
         const monitorLookup = res.data.data.monitors.reduce((acc, monitor) => {

--- a/Server/controllers/monitorController.js
+++ b/Server/controllers/monitorController.js
@@ -271,7 +271,6 @@ const getMonitorsByTeamId = async (req, res, next) => {
   try {
     const teamId = req.params.teamId;
     const monitors = await req.db.getMonitorsByTeamId(req, res);
-
     return res.json({
       success: true,
       msg: successMessages.MONITOR_GET_BY_USER_ID(teamId),

--- a/Server/db/mongo/modules/monitorModule.js
+++ b/Server/db/mongo/modules/monitorModule.js
@@ -379,7 +379,6 @@ const getMonitorsByTeamId = async (req, res) => {
 
     // Early return if limit is set to -1, indicating we don't want any checks
     if (limit === "-1") {
-      console.log("early return");
       return { monitors, monitorCount: monitorsCount };
     }
 

--- a/Server/db/mongo/modules/monitorModule.js
+++ b/Server/db/mongo/modules/monitorModule.js
@@ -378,7 +378,8 @@ const getMonitorsByTeamId = async (req, res) => {
       .limit(rowsPerPage);
 
     // Early return if limit is set to -1, indicating we don't want any checks
-    if (limit === -1) {
+    if (limit === "-1") {
+      console.log("early return");
       return { monitors, monitorCount: monitorsCount };
     }
 

--- a/Server/db/mongo/modules/monitorModule.js
+++ b/Server/db/mongo/modules/monitorModule.js
@@ -373,12 +373,18 @@ const getMonitorsByTeamId = async (req, res) => {
       sortOrder = -1;
     } else sortOrder = -1;
 
-    // This effectively removes limit, returning all checks
-    if (limit === undefined) limit = 0;
-
     const monitors = await Monitor.find(monitorQuery)
       .skip(skip)
       .limit(rowsPerPage);
+
+    // Early return if limit is set to -1, indicating we don't want any checks
+    if (limit === -1) {
+      return { monitors, monitorCount: monitorsCount };
+    }
+
+    // This effectively removes limit, returning all checks
+    if (limit === undefined) limit = 0;
+
     // Map each monitor to include its associated checks
     const monitorsWithChecks = await Promise.all(
       monitors.map(async (monitor) => {


### PR DESCRIPTION
This PR fixes the slow loading of the Incidents page.  The issue was I originally designed that endpoint to return checks with the monitors.  The lazy solution was to set the limit to one and only return one check, but that solution isn't sufficient when large numbers of montiors are present.  Solution is to set limit to -1 and return no checks, avoiding the `Promise.all` which runs a query for every monitor.

- [x] Return early if limit is set to `-1` to avoid appending checks to monitors when not needed
- [x] Update request in Incidents page to use `-1` for limit. 