### PR TITLE
Fix/db index

### DIFF
--- a/Server/db/mongo/modules/checkModule.js
+++ b/Server/db/mongo/modules/checkModule.js
@@ -150,7 +150,6 @@ const getTeamChecks = async (req) => {
 
   // Get monitorIDs
   const userMonitors = await Monitor.find({ teamId: teamId }).select("_id");
-  const monitorIds = userMonitors.map((monitor) => monitor._id);
 
   //Build check query
   // Default limit to 0 if not provided
@@ -158,7 +157,7 @@ const getTeamChecks = async (req) => {
   // Default sort order is newest -> oldest
   sortOrder = sortOrder === "asc" ? 1 : -1;
 
-  checksQuery = { monitorId: { $in: monitorIds } };
+  checksQuery = { monitorId: { $in: userMonitors } };
 
   if (filter !== undefined) {
     checksQuery.status = false;
@@ -191,8 +190,8 @@ const getTeamChecks = async (req) => {
   const checks = await Check.find(checksQuery)
     .skip(skip)
     .limit(rowsPerPage)
-    .sort({ createdAt: sortOrder });
-
+    .sort({ createdAt: sortOrder })
+    .select(["monitorId", "status", "responseTime", "statusCode", "message"]);
   return { checksCount, checks };
 };
 

--- a/Server/db/mongo/modules/checkModule.js
+++ b/Server/db/mongo/modules/checkModule.js
@@ -149,13 +149,12 @@ const getTeamChecks = async (req) => {
   let { sortOrder, limit, dateRange, filter, page, rowsPerPage } = req.query;
 
   // Get monitorIDs
-  const userMonitors = await Monitor.find({ teamId: teamId });
+  const userMonitors = await Monitor.find({ teamId: teamId }).select("_id");
   const monitorIds = userMonitors.map((monitor) => monitor._id);
 
   //Build check query
   // Default limit to 0 if not provided
-  limit = limit === "undefined" ? 0 : limit;
-
+  limit = limit === undefined ? 0 : limit;
   // Default sort order is newest -> oldest
   sortOrder = sortOrder === "asc" ? 1 : -1;
 

--- a/Server/models/Check.js
+++ b/Server/models/Check.js
@@ -19,6 +19,7 @@ const CheckSchema = mongoose.Schema(
       type: mongoose.Schema.Types.ObjectId,
       ref: "Monitor",
       immutable: true,
+      index: true,
     },
     /**
      * Status of the check (true for up, false for down).
@@ -27,6 +28,7 @@ const CheckSchema = mongoose.Schema(
      */
     status: {
       type: Boolean,
+      index: true,
     },
     /**
      * Response time of the check in milliseconds.
@@ -43,6 +45,7 @@ const CheckSchema = mongoose.Schema(
      */
     statusCode: {
       type: Number,
+      index: true,
     },
     /**
      * Message or description of the check result.
@@ -68,5 +71,7 @@ const CheckSchema = mongoose.Schema(
     timestamps: true, // Adds createdAt and updatedAt timestamps
   }
 );
+
+CheckSchema.index({ createdAt: 1 });
 
 module.exports = mongoose.model("Check", CheckSchema);


### PR DESCRIPTION
This PR optimizes the getTeamChecks query

- [x] Add DB indexes
- [x] Modify monitor query to return ID only, allows us to skip mapping monitors to IDs
- [x] Return only needed fields