### PR TITLE
Feat/be/monitor sort and filter, #498, #704

### DIFF
--- a/Client/src/Pages/Incidents/index.jsx
+++ b/Client/src/Pages/Incidents/index.jsx
@@ -25,17 +25,20 @@ const Incidents = () => {
   useEffect(() => {
     const fetchMonitors = async () => {
       setLoading(true);
-      const res = await networkService.getMonitorsByTeamId(
-        authState.authToken,
-        authState.user.teamId,
-        -1,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null
-      );
+      const res = await networkService.getMonitorsByTeamId({
+        authToken: authState.authToken,
+        teamId: authState.user.teamId,
+        limit: -1,
+        types: null,
+        status: null,
+        checkOrder: null,
+        normalize: null,
+        page: null,
+        rowsPerPage: null,
+        filter: null,
+        field: null,
+        order: null,
+      });
       // Reduce to a lookup object for 0(1) lookup
       if (res?.data?.data?.monitors?.length > 0) {
         const monitorLookup = res.data.data.monitors.reduce((acc, monitor) => {

--- a/Client/src/Pages/Monitors/Home/MonitorTable/index.jsx
+++ b/Client/src/Pages/Monitors/Home/MonitorTable/index.jsx
@@ -142,20 +142,20 @@ const MonitorTable = ({ isAdmin }) => {
       try {
         const { authToken } = authState;
         const user = jwtDecode(authToken);
-        const res = await networkService.getMonitorsByTeamId(
+        const res = await networkService.getMonitorsByTeamId({
           authToken,
-          user.teamId,
-          25,
-          ["http", "ping"],
-          null,
-          "desc",
-          true,
-          page,
-          rowsPerPage,
-          null,
-          null,
-          null
-        );
+          teamId: user.teamId,
+          limit: 25,
+          types: ["http", "ping"],
+          status: null,
+          checkOrder: "desc",
+          normalize: true,
+          page: page,
+          rowsPerPage: rowsPerPage,
+          filter: null,
+          field: null,
+          order: null,
+        });
         setMonitors(res?.data?.data?.monitors ?? []);
         setMonitorCount(res?.data?.data?.monitorCount ?? 0);
       } catch (error) {

--- a/Client/src/Pages/Monitors/Home/MonitorTable/index.jsx
+++ b/Client/src/Pages/Monitors/Home/MonitorTable/index.jsx
@@ -153,8 +153,8 @@ const MonitorTable = ({ isAdmin }) => {
           page,
           rowsPerPage,
           null,
-          "createdAt",
-          "desc"
+          null,
+          null
         );
         setMonitors(res?.data?.data?.monitors ?? []);
         setMonitorCount(res?.data?.data?.monitorCount ?? 0);

--- a/Client/src/Pages/Monitors/Home/MonitorTable/index.jsx
+++ b/Client/src/Pages/Monitors/Home/MonitorTable/index.jsx
@@ -151,7 +151,10 @@ const MonitorTable = ({ isAdmin }) => {
           "desc",
           true,
           page,
-          rowsPerPage
+          rowsPerPage,
+          null,
+          "createdAt",
+          "desc"
         );
         setMonitors(res?.data?.data?.monitors ?? []);
         setMonitorCount(res?.data?.data?.monitorCount ?? 0);

--- a/Client/src/Pages/PageSpeed/index.jsx
+++ b/Client/src/Pages/PageSpeed/index.jsx
@@ -29,17 +29,20 @@ const PageSpeed = ({ isAdmin }) => {
     const fetchMonitors = async () => {
       try {
         setIsLoading(true);
-        const res = await networkService.getMonitorsByTeamId(
-          authToken,
-          user.teamId,
-          10,
-          ["pagespeed"],
-          null,
-          "desc",
-          true,
-          null,
-          null
-        );
+        const res = await networkService.getMonitorsByTeamId({
+          authToken: authToken,
+          teamId: user.teamId,
+          limit: 10,
+          types: ["pagespeed"],
+          status: null,
+          checkOrder: "desc",
+          normalize: true,
+          page: null,
+          rowsPerPage: null,
+          filter: null,
+          field: null,
+          order: null,
+        });
         if (res?.data?.data?.monitors) {
           setMonitors(res.data.data.monitors);
         }

--- a/Client/src/Utils/NetworkService.js
+++ b/Client/src/Utils/NetworkService.js
@@ -98,7 +98,7 @@ class NetworkService {
     limit,
     types,
     status,
-    sortOrder,
+    checkOrder,
     normalize,
     page,
     rowsPerPage
@@ -112,7 +112,7 @@ class NetworkService {
       });
     }
     if (status) params.append("status", status);
-    if (sortOrder) params.append("sortOrder", sortOrder);
+    if (checkOrder) params.append("checkOrder", checkOrder);
     if (normalize) params.append("normalize", normalize);
     if (page) params.append("page", page);
     if (rowsPerPage) params.append("rowsPerPage", rowsPerPage);

--- a/Client/src/Utils/NetworkService.js
+++ b/Client/src/Utils/NetworkService.js
@@ -83,29 +83,37 @@ class NetworkService {
    * ************************************
    *
    * @async
-   * @param {string} authToken - The authorization token to be used in the request header.
-   * @param {string} userId - The ID of the user whose monitors are to be retrieved.
-   * @param {number} [limit] - The maximum number of monitors to retrieve.
-   * @param {Array<string>} [types] - The types of monitors to retrieve.
-   * @param {string} [status] - The status of the monitors to retrieve.
-   * @param {string} [sortOrder] - The order in which to sort the retrieved monitors.
-   * @param {boolean} [normalize] - Whether to normalize the retrieved monitors.
+   * @param {Object} config - The configuration object.
+   * @param {string} config.authToken - The authorization token to be used in the request header.
+   * @param {string} config.teamId - The ID of the team whose monitors are to be retrieved.
+   * @param {number} [config.limit] - The maximum number of monitors to retrieve.
+   * @param {Array<string>} [config.types] - The types of monitors to retrieve.
+   * @param {string} [config.status] - The status of the monitors to retrieve.
+   * @param {string} [config.checkOrder] - The order in which to sort the retrieved monitors.
+   * @param {boolean} [config.normalize] - Whether to normalize the retrieved monitors.
+   * @param {number} [config.page] - The page number for pagination.
+   * @param {number} [config.rowsPerPage] - The number of rows per page for pagination.
+   * @param {string} [config.filter] - The filter to apply to the monitors.
+   * @param {string} [config.field] - The field to sort by.
+   * @param {string} [config.order] - The order in which to sort the field.
    * @returns {Promise<AxiosResponse>} The response from the axios GET request.
    */
-  async getMonitorsByTeamId(
-    authToken,
-    teamId,
-    limit,
-    types,
-    status,
-    checkOrder,
-    normalize,
-    page,
-    rowsPerPage,
-    filter,
-    field,
-    order
-  ) {
+  async getMonitorsByTeamId(config) {
+    const {
+      authToken,
+      teamId,
+      limit,
+      types,
+      status,
+      checkOrder,
+      normalize,
+      page,
+      rowsPerPage,
+      filter,
+      field,
+      order,
+    } = config;
+
     const params = new URLSearchParams();
 
     if (limit) params.append("limit", limit);

--- a/Client/src/Utils/NetworkService.js
+++ b/Client/src/Utils/NetworkService.js
@@ -101,7 +101,10 @@ class NetworkService {
     checkOrder,
     normalize,
     page,
-    rowsPerPage
+    rowsPerPage,
+    filter,
+    field,
+    order
   ) {
     const params = new URLSearchParams();
 
@@ -116,6 +119,9 @@ class NetworkService {
     if (normalize) params.append("normalize", normalize);
     if (page) params.append("page", page);
     if (rowsPerPage) params.append("rowsPerPage", rowsPerPage);
+    if (filter) params.append("filter", filter);
+    if (field) params.append("field", field);
+    if (order) params.append("order", order);
 
     return this.axiosInstance.get(
       `/monitors/team/${teamId}?${params.toString()}`,

--- a/Server/db/mongo/modules/monitorModule.js
+++ b/Server/db/mongo/modules/monitorModule.js
@@ -356,9 +356,13 @@ const getMonitorsByTeamId = async (req, res) => {
       page,
       rowsPerPage,
       filter,
+      field,
+      order,
     } = req.query || {};
+
     const monitorQuery = { teamId: req.params.teamId, type };
     // Add filter if provided
+    // $options: "i" makes the search case-insensitive
     if (filter !== undefined) {
       monitorQuery.$or = [
         { name: { $regex: filter, $options: "i" } },
@@ -385,9 +389,16 @@ const getMonitorsByTeamId = async (req, res) => {
       checkOrder = -1;
     } else checkOrder = -1;
 
+    // Sort order for monitors
+    let sort = {};
+    if (field !== undefined && order !== undefined) {
+      sort[field] = order === "asc" ? 1 : -1;
+    }
+
     const monitors = await Monitor.find(monitorQuery)
       .skip(skip)
-      .limit(rowsPerPage);
+      .limit(rowsPerPage)
+      .sort(sort);
 
     // Early return if limit is set to -1, indicating we don't want any checks
     if (limit === "-1") {

--- a/Server/db/mongo/modules/monitorModule.js
+++ b/Server/db/mongo/modules/monitorModule.js
@@ -359,8 +359,10 @@ const getMonitorsByTeamId = async (req, res) => {
       field,
       order,
     } = req.query || {};
-
-    const monitorQuery = { teamId: req.params.teamId, type };
+    const monitorQuery = { teamId: req.params.teamId };
+    if (type !== undefined) {
+      monitorQuery.type = type;
+    }
     // Add filter if provided
     // $options: "i" makes the search case-insensitive
     if (filter !== undefined) {

--- a/Server/validation/joi.js
+++ b/Server/validation/joi.js
@@ -180,7 +180,7 @@ const getMonitorsByTeamIdValidation = joi.object({
 
 const getMonitorsByTeamIdQueryValidation = joi.object({
   status: joi.boolean(),
-  sortOrder: joi.string().valid("asc", "desc"),
+  checkOrder: joi.string().valid("asc", "desc"),
   limit: joi.number(),
   normalize: joi.boolean(),
   type: joi
@@ -191,6 +191,9 @@ const getMonitorsByTeamIdQueryValidation = joi.object({
     ),
   page: joi.number(),
   rowsPerPage: joi.number(),
+  filter: joi.string(),
+  field: joi.string(),
+  order: joi.string().valid("asc", "desc"),
 });
 
 const getMonitorStatsByIdParamValidation = joi.object({


### PR DESCRIPTION
This PR implements sorting and filtering for monitors

- [x] Add validations for three new params for fetching monitors
  - [x] `filter` - arbirtary string which will filter by name or url
  - [x] `field` - arbitrary string that decalres which monitor field to sort on
  - [x] `order` - sort order, `asc` or `desc`
- [x] Update endpoint to use these params
- [x] Update network service to take a config object for clarity  
- [x] Rename param used for check sorting from `sortOrder` to `checkOrder` for clarity