### PR TITLE
Remove maintenance from sidebar and comment out routes

### DIFF
--- a/Client/src/App.jsx
+++ b/Client/src/App.jsx
@@ -83,14 +83,14 @@ function App() {
             path="integrations"
             element={<ProtectedRoute Component={Integrations} />}
           />
-          <Route
+          {/* <Route
             path="maintenance"
             element={<ProtectedRoute Component={MaintenanceWithAdminProp} />}
-          />
-          <Route
+          /> */}
+          {/* <Route
             path="/maintenance/create"
             element={<CreateNewMaintenanceWindow />}
-          />
+          /> */}
           <Route
             path="settings"
             element={<ProtectedRoute Component={SettingsWithAdminProp} />}

--- a/Client/src/Components/Sidebar/index.jsx
+++ b/Client/src/Components/Sidebar/index.jsx
@@ -55,7 +55,7 @@ const menu = [
   },
   { name: "Incidents", path: "incidents", icon: <Incidents /> },
   // { name: "Status pages", path: "status", icon: <StatusPages /> },
-  { name: "Maintenance", path: "maintenance", icon: <Maintenance /> },
+  // { name: "Maintenance", path: "maintenance", icon: <Maintenance /> },
   // { name: "Integrations", path: "integrations", icon: <Integrations /> },
   {
     name: "Account",


### PR DESCRIPTION
This PR temporarliy comments out the Maintenance Window feature

- [x] Comment out link in Sidebar
- [x] Comment out routes in app router 