### PR TITLE
Feat/quickstart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 .vscode
 *.sh
 !uptime.sh
-!quickstart.sh

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .vscode
 *.sh
 !uptime.sh
+!quickstart.sh

--- a/Docker/.gitignore
+++ b/Docker/.gitignore
@@ -1,4 +1,5 @@
 *.sh
+!quickstart.sh
 !build_images.sh
 mongo/data/*
 redis/data/*

--- a/Docker/mongoDB.Dockerfile
+++ b/Docker/mongoDB.Dockerfile
@@ -1,3 +1,4 @@
 FROM mongo
+COPY ./Docker/mongo/init/create_users.js /docker-entrypoint-initdb.d/
 EXPOSE 27017
 CMD ["mongod"]

--- a/Docker/quickstart/docker-compose.yaml
+++ b/Docker/quickstart/docker-compose.yaml
@@ -1,0 +1,34 @@
+services:
+  client:
+    image: bluewaveuptime/uptime_client:latest
+    ports:
+      - "80:80"
+      - "443:443"
+    depends_on:
+      - server
+    volumes:
+      - ./nginx/conf.d:/etc/nginx/conf.d/:ro
+  server:
+    image: bluewaveuptime/uptime_server:latest
+    ports:
+      - "5000:5000"
+    env_file:
+      - server.env
+    depends_on:
+      - redis
+      - mongodb
+  redis:
+    image: bluewaveuptime/uptime_redis:latest
+    ports:
+      - "6379:6379"
+    volumes:
+      - ./redis/data:/data
+  mongodb:
+    image: bluewaveuptime/uptime_database_mongo:latest
+    command: ["mongod", "--quiet", "--auth"]
+    ports:
+      - "27017:27017"
+    volumes:
+      - ./mongo/data:/data/db
+    env_file:
+      - mongo.env

--- a/Docker/quickstart/quickstart.sh
+++ b/Docker/quickstart/quickstart.sh
@@ -1,0 +1,123 @@
+default_server_base_url="http://localhost:5000/api/v1" 
+default_client_host="http://localhost"
+default_jwt_secret="my_secret"
+default_db_type="MongoDB"
+default_redis_host="redis"
+default_redis_port=6379
+default_token_ttl="99d"
+
+default_db_username="uptime_user"
+default_db_password="uptime_password" 
+
+default_system_email_host="smtp.gmail.com"
+default_system_email_port=465
+
+
+echo "Welcome to the Uptime Monitor Setup Script! \n"
+echo
+
+echo "Configuring server"
+printf '%*s\n' "${COLUMNS:-$(tput cols)}" '' | tr ' ' '*'
+echo
+
+db_type=$default_db_type
+redis_host=$default_redis_host
+redis_port=$default_redis_port
+jwt_secret=$default_jwt_secret
+
+
+read -p "Enter a username for your database [$default_db_username]: " db_username
+db_username="${db_username:-$default_db_username}"
+
+read -p "Enter a password for your database [$default_db_password]: " db_password
+db_password="${db_password:-$default_db_password}"
+
+read -p "Enter your system email host [$default_system_email_host]: " system_email_host
+system_email_host="${system_email_host:-$default_system_email_host}"
+echo "System email host: $system_email_host"
+echo
+
+read -p "Enter your DB connection string [$default_db_connection_string]: " db_connection_string
+db_connection_string="mongodb://${db_username}:${db_password}@mongodb:27017/uptime_db"
+echo "DB connection string: $db_connection_string"
+echo
+
+read -p "Enter your system email port [$default_system_email_port]: " system_email_port
+system_email_port="${system_email_port:-$default_system_email_port}"
+echo "System email port: $system_email_port"
+echo
+
+
+read -p "Enter your system email address: " system_email_address
+echo "System email address: $system_email_address"
+echo
+
+read -p "Enter your system email password: " system_email_password
+echo "System email password: $system_email_password"
+echo
+
+read -p "Enter your Token TTL [$default_token_ttl]: " token_ttl
+token_ttl="${token_ttl:-$default_token_ttl}"
+echo "Token TTL: $token_ttl"
+echo
+
+read -p "Enter your Pagespeed API key: " pagespeed_api_key
+echo "Pagespeed API key: $pagespeed_api_key"
+echo
+
+echo "Writing to ./server.env"
+echo
+
+{
+    echo "CLIENT_HOST=\"$client_host\""
+    echo "JWT_SECRET=\"$jwt_secret\""
+    echo "DB_TYPE=\"$db_type\""
+    echo "DB_CONNECTION_STRING=\"$db_connection_string\""
+    echo "REDIS_HOST=\"$redis_host\""
+    echo "REDIS_PORT=$redis_port"
+    echo "SYSTEM_EMAIL_HOST=\"$system_email_host\""
+    echo "SYSTEM_EMAIL_PORT=$system_email_port"
+    echo "SYSTEM_EMAIL_ADDRESS=\"$system_email_address\""
+    echo "SYSTEM_EMAIL_PASSWORD=\"$system_email_password\""
+    echo "TOKEN_TTL=\"$token_ttl\""
+    echo "PAGESPEED_API_KEY=\"$pagespeed_api_key\""
+} > ./server.env
+
+
+echo 
+{
+    echo USERNAME_ENV_VAR=${db_username}
+    echo PASSWORD_ENV_VAR=${db_password}
+} > ./mongo.env
+
+mkdir -p ./nginx/conf.d/
+
+
+cat <<EOL > ./nginx/conf.d/default.conf
+server {
+    listen       80;
+    listen  [::]:80;
+
+    server_name uptime-demo.bluewavelabs.ca;
+    server_tokens off;
+
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+        try_files \$uri \$uri/ /index.html;
+    }
+    
+    location /api/ {
+        proxy_pass http://server:5000/api/;
+        proxy_http_version 1.1;
+        proxy_set_header Host \$host;
+        proxy_set_header X-Real-IP \$remote_addr;
+        proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto \$scheme;
+    }
+}
+EOL

--- a/README.md
+++ b/README.md
@@ -136,8 +136,8 @@ Also check other developer and contributor-friendly projects of BlueWave:
 
 #### <u> Quickstart for Users</u><a id="user-quickstart"></a>
 
-1. Download our [Docker Compose File](Docker/quickstart/docker-compose.yaml)
-2. Download our [Quickstart script](Docker/quickstart/quickstart.sh)
+1. Download our [Docker Compose File](/Docker/quickstart/docker-compose.yaml)
+2. Download our [Quickstart script](/Docker/quickstart/quickstart.sh)
 3. Place these files in a directory of your choice
 4. Run `quickstart.sh` and generate config files
 5. Run `docker compose up` to start the application

--- a/README.md
+++ b/README.md
@@ -136,8 +136,8 @@ Also check other developer and contributor-friendly projects of BlueWave:
 
 #### <u> Quickstart for Users</u><a id="user-quickstart"></a>
 
-1. Download our [Docker Compose File]()
-2. Download our [Quickstart script]()
+1. Download our [Docker Compose File](Docker/quickstart/docker-compose.yaml)
+2. Download our [Quickstart script](Docker/quickstart/quickstart.sh)
 3. Place these files in a directory of your choice
 4. Run `quickstart.sh` and generate config files
 5. Run `docker compose up` to start the application

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Also check other developer and contributor-friendly projects of BlueWave:
 
 - Clone this repository to your local machine
 
+1.  [Quickstart for Users](#user-quickstart)
 1.  [Quickstart for Developers](#dev-quickstart)
 1.  [Docker Compose](#docker-compose)
 1.  [Installation (Client)](#client)
@@ -132,6 +133,15 @@ Also check other developer and contributor-friendly projects of BlueWave:
 1.  [Contributors](#contributors)
 
 ---
+
+#### <u> Quickstart for Users</u><a id="user-quickstart"></a>
+
+1. Download our [Docker Compose File]()
+2. Download our [Quickstart script]()
+3. Place these files in a directory of your choice
+4. Run `quickstart.sh` and generate config files
+5. Run `docker compose up` to start the application
+6. Application is running at `http://localhost`
 
 #### <u>Quickstart for Developers</u> <a id="dev-quickstart"></a>
 


### PR DESCRIPTION
This PR adds a quickstart docker compose file and setup script for end users.  The script creates all the needed config files for the user with minimal input to start a client runinng on `http://localhost` and a server running on `http://localhost:5000`.

The docker compose file differs from our regular docker compose file in that there is no HTTPS option.  Advanced users can configure that on their own if they decide they want to added security.  As this will probably be used locally HTTPS may not be a requirement for most users.

This feature is useful for users that want to start with minimal fuss.  It would be ideal to be able to just run `docker compose up` but some config is required for the server to work properly.  We can look at allowing this setup to be added to the app itself later, for now this is the easiest way I can think of.

- [x] Add a quickstart folder that contains
  - [x] A docker compose file with minimal setup required
  - [x] A script to initialize those values that are required and create the required config files  