### PR TITLE
userId -> teamId

### DIFF
--- a/Client/src/Pages/Incidents/IncidentTable/index.jsx
+++ b/Client/src/Pages/Incidents/IncidentTable/index.jsx
@@ -55,7 +55,7 @@ const IncidentTable = ({ monitors, selectedMonitor, filter }) => {
         if (selectedMonitor === "0") {
           res = await networkService.getChecksByTeam({
             authToken: authToken,
-            userId: user.teamId,
+            teamId: user.teamId,
             sortOrder: "desc",
             limit: null,
             dateRange: null,


### PR DESCRIPTION
This PR fixes an incorrectly named parameter in the Incidents page

- [x] `userId` -> `teamId`