### PR TITLE
Fix typo in monitor details page

### DIFF
--- a/Client/src/Pages/Monitors/Details/PaginationTable/index.jsx
+++ b/Client/src/Pages/Monitors/Details/PaginationTable/index.jsx
@@ -42,7 +42,7 @@ const PaginationTable = ({ monitorId, dateRange }) => {
       try {
         const res = await networkService.getChecksByMonitor({
           authToken: authToken,
-          monitoirId: monitorId,
+          monitorId: monitorId,
           sortOrder: "desc",
           limit: null,
           dateRange: dateRange,


### PR DESCRIPTION
This PR fixes a typo in the Monitor details page

- [x] Fix typo `monitoir` -> `monitor`