### PR TITLE
Add bluewave server to swagger config

### DIFF
--- a/Docker/nginx/conf.d/default.conf
+++ b/Docker/nginx/conf.d/default.conf
@@ -24,8 +24,8 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
-    location /api-doc/ {
-        proxy_pass http://server:5000/api-doc/;
+    location /api-docs/ {
+        proxy_pass http://server:5000/api-docs/;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -58,8 +58,8 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
-    location /api-doc/ {
-        proxy_pass http://server:5000/api-doc/;
+    location /api-docs/ {
+        proxy_pass http://server:5000/api-docs/;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
This PR adds the Bluewave Labs demo server to the Swagger server list