### PR TITLE
set default url to empty string

### DIFF
--- a/Client/src/Features/Settings/settingsSlice.js
+++ b/Client/src/Features/Settings/settingsSlice.js
@@ -3,7 +3,7 @@ import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
 
 const initialState = {
   isLoading: false,
-  apiBaseUrl: "http://localhost:5000/api/v1",
+  apiBaseUrl: "",
   logLevel: "debug",
 };
 


### PR DESCRIPTION
This PR sets the default base API url to the empty string