### PR TITLE
Add a fallback URL

### DIFF
--- a/Client/src/Utils/NetworkService.js
+++ b/Client/src/Utils/NetworkService.js
@@ -1,5 +1,6 @@
 import axios from "axios";
 const BASE_URL = import.meta.env.VITE_APP_API_BASE_URL;
+const FALLBACK_BASE_URL = "http://localhost:5000/api/v1";
 import { logger } from "./Logger";
 class NetworkService {
   constructor(store) {
@@ -11,6 +12,8 @@ class NetworkService {
       const state = store.getState();
       if (BASE_URL === undefined && state.settings.apiBaseUrl) {
         baseURL = state.settings.apiBaseUrl;
+      } else {
+        baseURL = FALLBACK_BASE_URL;
       }
       this.setBaseUrl(baseURL);
     });


### PR DESCRIPTION
This PR adds a fallback base API URL in case the user does not specify one in initial setup.  
- [x] Add a fallback base API URL to FE `NetworkService`