### PR TITLE
Correct base URL logic

### DIFF
--- a/Client/src/Utils/NetworkService.js
+++ b/Client/src/Utils/NetworkService.js
@@ -10,7 +10,9 @@ class NetworkService {
     this.setBaseUrl(baseURL);
     this.unsubscribe = store.subscribe(() => {
       const state = store.getState();
-      if (BASE_URL === undefined && state.settings.apiBaseUrl) {
+      if (BASE_URL !== undefined) {
+        baseURL = BASE_URL;
+      } else if (state?.settings?.apiBaseUrl ?? null) {
         baseURL = state.settings.apiBaseUrl;
       } else {
         baseURL = FALLBACK_BASE_URL;


### PR DESCRIPTION
This PR fixes the logic for loading the base API url

- [x] Load Base URL in the following priority:
  1. ENV var
  2. Settings var
  3. Fallback localhost 