### PR TITLE
Allow demo user to create maintenance windows

### DIFF
--- a/Client/src/Pages/Maintenance/index.jsx
+++ b/Client/src/Pages/Maintenance/index.jsx
@@ -93,7 +93,7 @@ const Maintenance = ({ isAdmin }) => {
           />
         </Stack>
       )}
-      {isAdmin && maintenanceWindows.length === 0 && (
+      {maintenanceWindows.length === 0 && (
         <Fallback
           title="maintenance window"
           checks={[
@@ -102,7 +102,7 @@ const Maintenance = ({ isAdmin }) => {
             "Stop sending alerts in maintenance windows",
           ]}
           link="/maintenance/create"
-          isAdmin={isAdmin}
+          isAdmin={true}
         />
       )}
     </Box>

--- a/Client/src/Pages/Monitors/Home/index.jsx
+++ b/Client/src/Pages/Monitors/Home/index.jsx
@@ -59,18 +59,19 @@ const Monitors = ({ isAdmin }) => {
               mt={theme.spacing(5)}
             >
               <Greeting type="uptime" />
-              {monitorState?.monitorsSummary?.monitors?.length !== 0 && (
-                <Button
-                  variant="contained"
-                  color="primary"
-                  onClick={() => {
-                    navigate("/monitors/create");
-                  }}
-                  sx={{ fontWeight: 500 }}
-                >
-                  Create monitor
-                </Button>
-              )}
+              {isAdmin &&
+                monitorState?.monitorsSummary?.monitors?.length !== 0 && (
+                  <Button
+                    variant="contained"
+                    color="primary"
+                    onClick={() => {
+                      navigate("/monitors/create");
+                    }}
+                    sx={{ fontWeight: 500 }}
+                  >
+                    Create monitor
+                  </Button>
+                )}
             </Stack>
           </Box>
           {isAdmin && monitorState?.monitorsSummary?.monitors?.length === 0 && (


### PR DESCRIPTION
This PR allows users with the "demo" role to view and create maintenance windows.

- [x] Enable maintenance window for "demo" user
- [x] Hide create monitor button for non admin users 