### PR TITLE
fix: add css to fix the current password widget under account>password

### DIFF
--- a/Client/src/Components/Inputs/Field/index.jsx
+++ b/Client/src/Components/Inputs/Field/index.jsx
@@ -74,6 +74,7 @@ const Field = forwardRef(
           "&:has(.input-error) .MuiOutlinedInput-root fieldset": {
             borderColor: theme.palette.error.text,
           },
+          display: hidden ? "none" : "",
         }}
       >
         {label && (
@@ -142,7 +143,7 @@ const Field = forwardRef(
                   },
                 }
               : {
-                  display: hidden ? "none" : "",
+                  
                 }
           }
           InputProps={{


### PR DESCRIPTION
## Fixes https://github.com/bluewave-labs/bluewave-uptime/issues/907 (Fix the "current password" widget)

- Added the CSS to fix current password widget in light/dark mode.
![Screenshot 2024-10-12 002318](https://github.com/user-attachments/assets/756e5c7d-861e-4a57-8c7b-dc78681a0f5e)
![Screenshot 2024-10-12 002329](https://github.com/user-attachments/assets/15ead897-2569-4198-84a2-2aff53cb584f)
