### PR TITLE
Fix Typo: "Derver" to "Server"

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -128,7 +128,7 @@ From the `Docker` directory run
 
 ---
 
-#### Starting the development derver <a href="#start-server" id="start-server"></a>
+#### Starting the development server <a href="#start-server" id="start-server"></a>
 
 - run `npm run dev` to start the development server
 

--- a/docs/users-guide/quickstart.md
+++ b/docs/users-guide/quickstart.md
@@ -128,7 +128,7 @@ From the `Docker` directory run
 
 ---
 
-#### Starting the development derver <a href="#start-server" id="start-server"></a>
+#### Starting the development server <a href="#start-server" id="start-server"></a>
 
 - run `npm run dev` to start the development server
 

--- a/guides/users-guide/quickstart.md
+++ b/guides/users-guide/quickstart.md
@@ -128,7 +128,7 @@ From the `Docker` directory run
 
 ---
 
-#### Starting the development derver <a href="#start-server" id="start-server"></a>
+#### Starting the development server <a href="#start-server" id="start-server"></a>
 
 - run `npm run dev` to start the development server
 


### PR DESCRIPTION
### Summary
This PR addresses a minor typo in the code where the word "derver" was incorrectly used instead of "server." This change improves clarity and ensures consistency throughout the codebase.

### Changes Made
Corrected the typo in the relevant files.

![image](https://github.com/user-attachments/assets/3a1f3944-2727-45e6-973e-6fee3c947a54)
