### PR TITLE
Fix: table header - issue#963

### DIFF
--- a/Client/src/Components/BasicTable/index.css
+++ b/Client/src/Components/BasicTable/index.css
@@ -120,7 +120,7 @@
   opacity: 0.4;
 }
 
-.monitors .MuiTable-root .MuiTableHead-root .MuiTableCell-root {
+.table-container .MuiTable-root .MuiTableHead-root .MuiTableCell-root {
   text-transform: uppercase;
   opacity: 0.8;
   font-size: var(--env-var-font-size-small-plus);

--- a/Client/src/Components/TabPanels/Account/TeamPanel.jsx
+++ b/Client/src/Components/TabPanels/Account/TeamPanel.jsx
@@ -223,6 +223,7 @@ const TeamPanel = () => {
 
   return (
     <TabPanel
+      className="team-panel table-container"
       value="team"
       sx={{
         "& h1": {

--- a/Client/src/Pages/Incidents/index.jsx
+++ b/Client/src/Pages/Incidents/index.jsx
@@ -61,7 +61,7 @@ const Incidents = () => {
   };
 
   return (
-    <Stack className="incidents" pt={theme.spacing(6)} gap={theme.spacing(12)}>
+    <Stack className="incidents table-container" pt={theme.spacing(6)} gap={theme.spacing(12)}>
       {loading ? (
         <SkeletonLayout />
       ) : (

--- a/Client/src/Pages/Maintenance/index.jsx
+++ b/Client/src/Pages/Maintenance/index.jsx
@@ -46,7 +46,7 @@ const Maintenance = ({ isAdmin }) => {
 
   return (
     <Box
-      className="maintenance"
+      className="maintenance table-container"
       sx={{
         ':has(> [class*="fallback__"])': {
           position: "relative",

--- a/Client/src/Pages/Monitors/Home/index.jsx
+++ b/Client/src/Pages/Monitors/Home/index.jsx
@@ -45,7 +45,7 @@ const Monitors = ({ isAdmin }) => {
     monitorState?.monitorsSummary?.monitors?.length === 0;
 
   return (
-    <Stack className="monitors" gap={theme.spacing(8)}>
+    <Stack className="monitors table-container" gap={theme.spacing(8)}>
       {loading ? (
         <SkeletonLayout />
       ) : (


### PR DESCRIPTION
Fixed styling of table headers of Incidents, maintenance and team table section as discussed in issue #963. Added a common class to the parent component that renders the table.

Before:
<img width="1102" alt="prev4" src="https://github.com/user-attachments/assets/cac8d5ff-d32e-4e97-8b61-0d2371a547be">
 
Fixed:
![Screenshot (80)](https://github.com/user-attachments/assets/2bdbc3b7-77bc-4890-97be-766d8b59b1a7)



closes #963 