### PR TITLE
Add ssl-checker, refactor fetchMonitorCertificate

### DIFF
--- a/Server/controllers/controllerUtils.js
+++ b/Server/controllers/controllerUtils.js
@@ -12,32 +12,15 @@ const handleError = (error, serviceName, method, status = 500) => {
 	return error;
 };
 
-const fetchMonitorCertificate = async (tls, monitor) => {
-	return new Promise((resolve, reject) => {
+const fetchMonitorCertificate = async (sslChecker, monitor) => {
+	try {
 		const monitorUrl = new URL(monitor.url);
 		const hostname = monitorUrl.hostname;
-		try {
-			let socket = tls.connect(
-				{
-					port: 443,
-					host: hostname,
-					servername: hostname, // this is required in case the server enabled SNI
-				},
-				() => {
-					try {
-						let x509Certificate = socket.getPeerX509Certificate();
-						resolve(x509Certificate);
-					} catch (error) {
-						reject(error);
-					} finally {
-						socket.end();
-					}
-				}
-			);
-		} catch (error) {
-			reject(error);
-		}
-	});
+		const cert = await sslChecker(hostname);
+		return cert;
+	} catch (error) {
+		throw error;
+	}
 };
 
 export { handleValidationError, handleError, fetchMonitorCertificate };

--- a/Server/controllers/monitorController.js
+++ b/Server/controllers/monitorController.js
@@ -12,18 +12,14 @@ import {
 	getMonitorStatsByIdQueryValidation,
 	getCertificateParamValidation,
 } from "../validation/joi.js";
-import * as tls from "tls";
+import sslChecker from "ssl-checker";
 
 const SERVICE_NAME = "monitorController";
 import { errorMessages, successMessages } from "../utils/messages.js";
 import jwt from "jsonwebtoken";
 import { getTokenFromHeaders } from "../utils/utils.js";
 import logger from "../utils/logger.js";
-import {
-	handleError,
-	handleValidationError,
-	fetchMonitorCertificate,
-} from "./controllerUtils.js";
+import { handleError, handleValidationError } from "./controllerUtils.js";
 
 /**
  * Returns all monitors
@@ -87,7 +83,7 @@ const getMonitorCertificate = async (req, res, next, fetchMonitorCertificate) =>
 	try {
 		const { monitorId } = req.params;
 		const monitor = await req.db.getMonitorById(monitorId);
-		const certificate = await fetchMonitorCertificate(tls, monitor);
+		const certificate = await fetchMonitorCertificate(sslChecker, monitor);
 		if (certificate && certificate.validTo) {
 			return res.status(200).json({
 				success: true,

--- a/Server/package-lock.json
+++ b/Server/package-lock.json
@@ -27,6 +27,7 @@
 				"nodemailer": "^6.9.14",
 				"ping": "0.4.4",
 				"sharp": "0.33.4",
+				"ssl-checker": "2.0.10",
 				"swagger-ui-express": "5.0.1",
 				"winston": "^3.13.0"
 			},
@@ -6001,6 +6002,12 @@
 			"dependencies": {
 				"memory-pager": "^1.0.2"
 			}
+		},
+		"node_modules/ssl-checker": {
+			"version": "2.0.10",
+			"resolved": "https://registry.npmjs.org/ssl-checker/-/ssl-checker-2.0.10.tgz",
+			"integrity": "sha512-SS6rrZocToJWHM1p6iVNb583ybB3UqT1fymCHSWuEdXDUqKA6O1D5Fb8KJVmhj3XKXE82IEWcr+idJrc4jUzFQ==",
+			"license": "MIT"
 		},
 		"node_modules/stack-trace": {
 			"version": "0.0.10",

--- a/Server/package.json
+++ b/Server/package.json
@@ -30,16 +30,17 @@
 		"nodemailer": "^6.9.14",
 		"ping": "0.4.4",
 		"sharp": "0.33.4",
+		"ssl-checker": "2.0.10",
 		"swagger-ui-express": "5.0.1",
 		"winston": "^3.13.0"
 	},
 	"devDependencies": {
-		"prettier": "^3.3.3",
-		"chai": "5.1.1",
-		"mocha": "10.7.3",
 		"c8": "10.1.2",
+		"chai": "5.1.1",
 		"esm": "3.2.25",
+		"mocha": "10.7.3",
 		"nodemon": "3.1.0",
+		"prettier": "^3.3.3",
 		"sinon": "19.0.2"
 	}
 }


### PR DESCRIPTION
This PR adds `ssl-checker` back to the project, in the end it is more reliable than using TLS to fetch certificates

- [x] Add ssl-checker to project
  - [x] refactor fetchMonitorCertificate
  - [x] rewrite tests  