### PR TITLE
feat/be/hardware-checks-model references #985

### DIFF
--- a/Server/db/models/HardwareCheck.js
+++ b/Server/db/models/HardwareCheck.js
@@ -46,8 +46,8 @@ const HardwareCheckSchema = mongoose.Schema(
 			default: () => ({}),
 		},
 		disk: {
-			type: discSchema,
-			default: () => ({}),
+			type: [discSchema],
+			default: () => [],
 		},
 		host: {
 			type: hostSchema,

--- a/Server/db/models/HardwareCheck.js
+++ b/Server/db/models/HardwareCheck.js
@@ -1,0 +1,60 @@
+import mongoose from "mongoose";
+
+const cpuSchema = mongoose.Schema({
+	physical_core: { type: Number, default: 0 },
+	logical_core: { type: Number, default: 0 },
+	frequency: { type: Number, default: 0 },
+	temperature: { type: Number, default: 0 },
+	free_percent: { type: Number, default: 0 },
+	usage_percent: { type: Number, default: 0 },
+});
+
+const memorySchema = mongoose.Schema({
+	total_bytes: { type: Number, default: 0 },
+	available_bytes: { type: Number, default: 0 },
+	used_bytes: { type: Number, default: 0 },
+	usage_percent: { type: Number, default: 0 },
+});
+
+const discSchema = mongoose.Schema({
+	read_speed_bytes: { type: Number, default: 0 },
+	write_speed_bytes: { type: Number, default: 0 },
+	total_bytes: { type: Number, default: 0 },
+	free_bytes: { type: Number, default: 0 },
+	usage_percent: { type: Number, default: 0 },
+});
+
+const hostSchema = mongoose.Schema({
+	os: { type: String, default: "" },
+	platform: { type: String, default: "" },
+	kernel_version: { type: String, default: "" },
+});
+
+const HardwareCheckSchema = mongoose.Schema(
+	{
+		monitorId: {
+			type: mongoose.Schema.Types.ObjectId,
+			ref: "Monitor",
+			immutable: true,
+		},
+		cpu: {
+			type: cpuSchema,
+			default: () => ({}),
+		},
+		memory: {
+			type: memorySchema,
+			default: () => ({}),
+		},
+		disk: {
+			type: discSchema,
+			default: () => ({}),
+		},
+		host: {
+			type: hostSchema,
+			default: () => ({}),
+		},
+	},
+	{ timestamps: true }
+);
+
+export default mongoose.model("HardwareCheck", HardwareCheckSchema);


### PR DESCRIPTION
This PR adds a mongoDB model for hardware monitoring

- [x] Add model for hardware monitoring

This model is based on data models provided by server monitoring agent developer @mertssmnoglu :

### CPU Response

```jsonc
{
    "physical_core": integer, // Physical cores
    "logical_core":  integer, // Logical cores aka Threads
    "frequency":     integer, // Frequency in mHz
    "temperature":   null,    // WIP
    "free_percent":  null,    // WIP
    "usage_percent": null     // WIP
}
```

### Memory Response

```jsonc
{
    "total_bytes":     integer, // Total space in bytes
    "available_bytes": integer, // Available space in bytes
    "used_bytes":      integer, // Used space in bytes      //* Total - Free - Buffers - Cached
    "usage_percent":   float    // Usage Percent            //* (Used / Total) * 100.0
}
```

### Disk Response

```jsonc
{
    "read_speed_bytes":  integer, // WIP
    "write_speed_bytes": integer, // WIP
    "total_bytes":       integer, // Total space of "/" in bytes
    "free_bytes":        integer, // WIP
    "usage_percent":     float    // WIP
}
```

### Host Response

```jsonc
{
    "os":             string, // linux, darwin, windows
    "platform":       string, // arch, debian, suse...
    "kernel_version": string, // 6.10.10, 6.0.0, 6.10.0-zen...
}
```