### PR TITLE
chore: changing rule on eslint

### DIFF
--- a/Client/.eslintrc.cjs
+++ b/Client/.eslintrc.cjs
@@ -14,5 +14,6 @@ module.exports = {
 	rules: {
 		"react/jsx-no-target-blank": "off",
 		"react-refresh/only-export-components": ["warn", { allowConstantExport: true }],
+		"react/no-unescaped-entities": "off",
 	},
 };

--- a/Server/index.js
+++ b/Server/index.js
@@ -36,7 +36,7 @@ import mjml2html from "mjml";
 
 // Settings Service and dependencies
 import SettingsService from "./service/settingsService.js";
-import AppSettings from "../db/models/AppSettings.js";
+import AppSettings from "./db/models/AppSettings.js";
 
 import db from "./db/mongo/MongoDB.js";
 const SERVICE_NAME = "Server";


### PR DESCRIPTION
This PR just corrects a rule that was bringing more trouble than good. 
This is the rule, and we do not need it because the workaround is much easier and readable.
https://kamrutkar.hashnode.dev/unescaped-html-entities-in-jsx-reactno-unescaped-entities

