### PR TITLE
Fix/be/refactor auth controller

### DIFF
--- a/Server/controllers/authController.js
+++ b/Server/controllers/authController.js
@@ -279,10 +279,10 @@ const editUser = async (req, res, next) => {
 			const user = await req.db.getUserByEmail(email);
 			// Compare passwords
 			const match = await user.comparePassword(req.body.password);
-			// If not a match, throw a 403
+			// If not a match, throw a 401
 			if (!match) {
 				const error = new Error(errorMessages.AUTH_INCORRECT_PASSWORD);
-				error.status = 403;
+				error.status = 401;
 				next(error);
 				return;
 			}

--- a/Server/controllers/authController.js
+++ b/Server/controllers/authController.js
@@ -350,7 +350,6 @@ const requestRecovery = async (req, res, next) => {
 		const name = user.firstName;
 		const { clientHost } = req.settingsService.getSettings();
 		const url = `${clientHost}/set-new-password/${recoveryToken.token}`;
-
 		const msgId = await req.emailService.buildAndSendEmail(
 			"passwordResetTemplate",
 			{
@@ -425,7 +424,6 @@ const resetPassword = async (req, res, next) => {
 	}
 	try {
 		const user = await req.db.resetPassword(req, res);
-
 		const appSettings = await req.settingsService.getSettings();
 		const token = issueToken(user._doc, tokenType.ACCESS_TOKEN, appSettings);
 		res.status(200).json({
@@ -455,11 +453,6 @@ const deleteUser = async (req, res, next) => {
 
 		// Check if the user exists
 		const user = await req.db.getUserByEmail(email);
-		if (!user) {
-			next(new Error(errorMessages.DB_USER_NOT_FOUND));
-			return;
-		}
-
 		// 1. Find all the monitors associated with the team ID if superadmin
 
 		const result = await req.db.getMonitorsByTeamId({

--- a/Server/controllers/authController.js
+++ b/Server/controllers/authController.js
@@ -346,32 +346,27 @@ const requestRecovery = async (req, res, next) => {
 	try {
 		const { email } = req.body;
 		const user = await req.db.getUserByEmail(email);
-		if (user) {
-			const recoveryToken = await req.db.requestRecoveryToken(req, res);
-			const name = user.firstName;
-			const email = req.body.email;
-			const { clientHost } = req.settingsService.getSettings();
-			const url = `${clientHost}/set-new-password/${recoveryToken.token}`;
+		const recoveryToken = await req.db.requestRecoveryToken(req, res);
+		const name = user.firstName;
+		const { clientHost } = req.settingsService.getSettings();
+		const url = `${clientHost}/set-new-password/${recoveryToken.token}`;
 
-			const msgId = await req.emailService.buildAndSendEmail(
-				"passwordResetTemplate",
-				{
-					name,
-					email,
-					url,
-				},
+		const msgId = await req.emailService.buildAndSendEmail(
+			"passwordResetTemplate",
+			{
+				name,
 				email,
-				"Bluewave Uptime Password Reset"
-			);
+				url,
+			},
+			email,
+			"Bluewave Uptime Password Reset"
+		);
 
-			return res.status(200).json({
-				success: true,
-				msg: successMessages.AUTH_CREATE_RECOVERY_TOKEN,
-				data: msgId,
-			});
-		} else {
-			throw new Error(errorMessages.FRIENDLY_ERROR);
-		}
+		return res.status(200).json({
+			success: true,
+			msg: successMessages.AUTH_CREATE_RECOVERY_TOKEN,
+			data: msgId,
+		});
 	} catch (error) {
 		next(handleError(error, SERVICE_NAME, "recoveryRequestController"));
 	}

--- a/Server/db/mongo/modules/userModule.js
+++ b/Server/db/mongo/modules/userModule.js
@@ -68,7 +68,7 @@ const insertUser = async (userData, imageFile) => {
 const getUserByEmail = async (email) => {
 	try {
 		// Need the password to be able to compare, removed .select()
-		// We can strip the hash before returing the user
+		// We can strip the hash before returning the user
 		const user = await UserModel.findOne({ email: email }).select("-profileImage");
 		if (user) {
 			return user;

--- a/Server/tests/controllers/authController.test.js
+++ b/Server/tests/controllers/authController.test.js
@@ -467,7 +467,7 @@ describe("Auth Controller - editUser", async () => {
 		});
 		await editUser(req, res, next);
 		expect(next.firstCall.args[0]).to.be.an("error");
-		expect(next.firstCall.args[0].status).to.equal(403);
+		expect(next.firstCall.args[0].status).to.equal(401);
 		expect(next.firstCall.args[0].message).to.equal(
 			errorMessages.AUTH_INCORRECT_PASSWORD
 		);

--- a/Server/tests/controllers/authController.test.js
+++ b/Server/tests/controllers/authController.test.js
@@ -812,9 +812,9 @@ describe("Auth Controller - deleteUser", () => {
 	afterEach(() => {
 		sinon.restore();
 	});
-	it("should return 404 if user is not found", async () => {
+	it("should throw an error if user is not found", async () => {
 		jwt.decode.returns({ email: "test@example.com" });
-		req.db.getUserByEmail.resolves(null);
+		req.db.getUserByEmail.throws(new Error(errorMessages.DB_USER_NOT_FOUND));
 
 		await deleteUser(req, res, next);
 


### PR DESCRIPTION
This PR refactors `authController` to remove some redundant checks.

`getUserByEmail` throws an `Error` at the db level if a user is not found, so a check to see if a user is found or not at the controller level is redundant.