### PR TITLE
Fixed the modal redirect bug

### DIFF
--- a/Client/src/Components/Dialog/genericDialog.jsx
+++ b/Client/src/Components/Dialog/genericDialog.jsx
@@ -12,6 +12,7 @@ const GenericDialog = ({ title, description, open, onClose, theme, children }) =
 			aria-describedby={ariaDescribedBy}
 			open={open}
 			onClose={onClose}
+			onClick={(e)=>e.stopPropagation()}
 		>
 			<Stack
 				gap={theme.spacing(2)}


### PR DESCRIPTION
Fixes #1027 

The problem was that the default behaviour of the Material UI Modal Component (used in GenericDialog component) was leading the propogation of the event . So I explicitly defined that on click, the event should not propogate.