### PR TITLE
Add link to logo

### DIFF
--- a/Client/src/Components/Sidebar/index.jsx
+++ b/Client/src/Components/Sidebar/index.jsx
@@ -181,6 +181,8 @@ function Sidebar() {
 					direction="row"
 					alignItems="center"
 					gap={theme.spacing(4)}
+					onClick={() => window.open("https://github.com/bluewave-labs/bluewave-uptime", "_blank", "noreferrer")} 
+					sx={{ cursor: "pointer" }}
 				>
 					<Stack
 						justifyContent="center"


### PR DESCRIPTION
- [x] This PR adds a link to the logo

    - [x] Set an onClick() listener to the icon (BU) and 'BlueWave Uptime'
    - [x] The [link](https://github.com/bluewave-labs/bluewave-uptime) opens up in a new tab as specified [here](https://github.com/bluewave-labs/bluewave-uptime/issues/951)
    - [x] The cursor switches to a pointer when hovering on the logo

Let me know if I need to make further changes. 

I apologize for taking so long. Still can't figure out the installation (stuck on the .env variables), I think it's my laptop. 
If testing is necessary, could someone else do it?