### PR TITLE
Fix/montiors border removal

### DIFF
--- a/Client/src/Components/Dialog/genericDialog.jsx
+++ b/Client/src/Components/Dialog/genericDialog.jsx
@@ -12,6 +12,7 @@ const GenericDialog = ({ title, description, open, onClose, theme, children }) =
 			aria-describedby={ariaDescribedBy}
 			open={open}
 			onClose={onClose}
+			onClick={(e)=>e.stopPropagation()}
 		>
 			<Stack
 				gap={theme.spacing(2)}

--- a/Client/src/Pages/Monitors/Home/CurrentMonitoring/index.jsx
+++ b/Client/src/Pages/Monitors/Home/CurrentMonitoring/index.jsx
@@ -20,8 +20,8 @@ const CurrentMonitoring = ({ totalMonitors, monitors, isAdmin }) => {
 			flex={1}
 			px={theme.spacing(10)}
 			py={theme.spacing(8)}
-			border={1}
-			borderColor={theme.palette.border.light}
+			// border={1}
+			// borderColor={theme.palette.border.light}
 			borderRadius={theme.shape.borderRadius}
 			backgroundColor={theme.palette.background.main}
 		>


### PR DESCRIPTION
Fixes #1064 

Removed the border from the monitors table component by commenting out the border details from it.