### PR TITLE
Issue-1069 : FE - Hardware Monitoring - Line Graph

### DIFF
--- a/Client/src/Components/Charts/LineGraph/index.jsx
+++ b/Client/src/Components/Charts/LineGraph/index.jsx
@@ -1,0 +1,132 @@
+import {
+	LineChart,
+	Line,
+	XAxis,
+	YAxis,
+	CartesianGrid,
+	Tooltip,
+	Legend,
+	ResponsiveContainer,
+} from "recharts";
+
+import PropTypes from "prop-types";
+import { useTheme } from "@emotion/react";
+import { Stack } from "@mui/material";
+import { useMemo } from "react";
+
+const LineGraph = ({
+	chartData = [],
+	chartConfig = {},
+	styleConfig = {},
+	onClickHandler,
+	onMouseEnterHandler,
+	onMouseMoveHandler,
+	onMouseLeaveHandler,
+}) => {
+	const theme = useTheme();
+
+	const memoizedChartData = useMemo(() => {
+		return chartData.length ? chartData : [];
+	}, [chartData]);
+
+	const { unit = "", metricName = "value" } = chartConfig;
+
+	const {
+		width = "100%",
+		height = 300,
+		chartStrokeColor = theme.palette.primary.main,
+		marginObject = { top: 5, right: 5, bottom: 5, left: 5 },
+	} = styleConfig;
+
+	if (!memoizedChartData.length) {
+		const noDataStyle = {
+			...theme.typography.h1,
+			fontFamily: theme.typography.fontFamily,
+			textAlign: "center",
+			marginBottom: "20px",
+		};
+		return (
+			<Stack spacing={1}>
+				<ResponsiveContainer
+					width={width}
+					height={height}
+				>
+					<LineChart
+						data={[]}
+						margin={{ bottom: 0 }}
+					>
+						<CartesianGrid strokeDasharray="3 3" />
+						<XAxis />
+						<YAxis />
+					</LineChart>
+				</ResponsiveContainer>
+				<div style={noDataStyle}>No chart data available</div>
+			</Stack>
+		);
+	}
+
+	return (
+		<ResponsiveContainer
+			width={width}
+			height={height}
+		>
+			<LineChart
+				data={memoizedChartData}
+				margin={marginObject}
+				onClick={onClickHandler}
+				onMouseEnter={onMouseEnterHandler}
+				onMouseMove={onMouseMoveHandler}
+				onMouseLeave={onMouseLeaveHandler}
+			>
+				<CartesianGrid strokeDasharray="3 3" />
+				<XAxis dataKey="time" />
+				<YAxis label={{ value: unit, angle: -90, position: "insideLeft" }} />
+				<Tooltip
+					formatter={(value) => {
+						return [`${value} ${unit}`, metricName];
+					}}
+				/>
+				<Legend
+					formatter={() => {
+						return metricName;
+					}}
+				/>
+				<Line
+					type="monotone"
+					dataKey="value"
+					stroke={chartStrokeColor}
+				/>
+			</LineChart>
+		</ResponsiveContainer>
+	);
+};
+
+LineGraph.propTypes = {
+	chartData: PropTypes.arrayOf(
+		PropTypes.shape({
+			time: PropTypes.string.isRequired,
+			value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+		})
+	),
+	chartConfig: PropTypes.shape({
+		unit: PropTypes.string,
+		metricName: PropTypes.string,
+	}),
+	styleConfig: PropTypes.shape({
+		width: PropTypes.number,
+		height: PropTypes.number,
+		chartStrokeColor: PropTypes.string,
+		marginObject: PropTypes.shape({
+			top: PropTypes.number,
+			right: PropTypes.number,
+			bottom: PropTypes.number,
+			left: PropTypes.number,
+		}),
+	}),
+	onClickHandler: PropTypes.func,
+	onMouseEnterHandler: PropTypes.func,
+	onMouseMoveHandler: PropTypes.func,
+	onMouseLeaveHandler: PropTypes.func,
+};
+
+export default LineGraph;


### PR DESCRIPTION
# Line Graph implemented, 

I have implemented the configurable Line Chart component according to https://recharts.org/en-US/api/LineChart

Configurable props:
- Y axis unit and name
- metricName for legend and tooltip 
- chart styles (margin, width, height,strokeColor)



## On the screenshot below you can see 3 chart. 


- on the first chart  there s only chart data

```html
			<LineGraph
				chartData={[
					{ time: "2024-10-01", value: 10 },
					{ time: "2024-10-02", value: 15 },
					{ time: "2024-10-03", value: 8 },
					{ time: "2024-10-04", value: 20 },
				]}
			/>
```

- on the second chart there are style and chart configs

```html
			<LineGraph
				chartData={[
					{ time: "2024-10-01", value: 10 },
					{ time: "2024-10-02", value: 15 },
					{ time: "2024-10-03", value: 8 },
					{ time: "2024-10-04", value: 20 },
				]}
				chartConfig={{ unit: "ms", metricName: "throughput" }}
				styleConfig={{ chartStrokeColor:"red", marginObject: { top: 55 } }}
			/>

```

- Lastly on the third chart you can see the behaviour when there s no data 


```html
			<LineGraph />
```

## Screenshots
![ThreeLineGraph](https://github.com/user-attachments/assets/d43b314d-9090-45e1-af12-d17ac2eb6145)



![largerScreen](https://github.com/user-attachments/assets/b91123e8-97d9-4f63-a1ea-38aaee859f05)
