### PR TITLE
fix/be/network service refactor

### DIFF
--- a/Server/index.js
+++ b/Server/index.js
@@ -40,6 +40,9 @@ import mjml2html from "mjml";
 import SettingsService from "./service/settingsService.js";
 import AppSettings from "./db/models/AppSettings.js";
 
+import StatusService from "./service/statusService.js";
+import NotificationService from "./service/notificationService.js";
+
 import db from "./db/mongo/MongoDB.js";
 const SERVICE_NAME = "Server";
 
@@ -125,10 +128,14 @@ const startApp = async () => {
 		nodemailer,
 		logger
 	);
-	const networkService = new NetworkService(db, emailService, axios, ping, logger, http);
+	const networkService = new NetworkService(axios, ping, logger, http);
+	const statusService = new StatusService(db, logger);
+	const notificationService = new NotificationService(emailService, db, logger);
 	const jobQueue = await JobQueue.createJobQueue(
 		db,
 		networkService,
+		statusService,
+		notificationService,
 		settingsService,
 		logger,
 		Queue,

--- a/Server/service/jobQueue.js
+++ b/Server/service/jobQueue.js
@@ -16,7 +16,14 @@ class JobQueue {
 	 * @param {SettingsService} settingsService - The settings service
 	 * @throws {Error}
 	 */
-	constructor(settingsService, logger, Queue, Worker) {
+	constructor(
+		statusService,
+		notificationService,
+		settingsService,
+		logger,
+		Queue,
+		Worker
+	) {
 		const settings = settingsService.getSettings() || {};
 
 		const { redisHost = "127.0.0.1", redisPort = 6379 } = settings;
@@ -31,6 +38,8 @@ class JobQueue {
 		this.workers = [];
 		this.db = null;
 		this.networkService = null;
+		this.statusService = statusService;
+		this.notificationService = notificationService;
 		this.settingsService = settingsService;
 		this.logger = logger;
 		this.Worker = Worker;
@@ -46,12 +55,21 @@ class JobQueue {
 	static async createJobQueue(
 		db,
 		networkService,
+		statusService,
+		notificationService,
 		settingsService,
 		logger,
 		Queue,
 		Worker
 	) {
-		const queue = new JobQueue(settingsService, logger, Queue, Worker);
+		const queue = new JobQueue(
+			statusService,
+			notificationService,
+			settingsService,
+			logger,
+			Queue,
+			Worker
+		);
 		try {
 			queue.db = db;
 			queue.networkService = networkService;
@@ -71,62 +89,97 @@ class JobQueue {
 		}
 	}
 
+	async isInMaintenanceWindow(monitorId) {
+		const maintenanceWindows = await this.db.getMaintenanceWindowsByMonitorId(monitorId);
+		// Check for active maintenance window:
+		const maintenanceWindowIsActive = maintenanceWindows.reduce((acc, window) => {
+			if (window.active) {
+				const start = new Date(window.start);
+				const end = new Date(window.end);
+				const now = new Date();
+				const repeatInterval = window.repeat || 0;
+
+				// If start is < now and end > now, we're in maintenance
+				if (start <= now && end >= now) return true;
+
+				// If maintenance window was set in the past with a repeat,
+				// we need to advance start and end to see if we are in range
+
+				while (start < now && repeatInterval !== 0) {
+					start.setTime(start.getTime() + repeatInterval);
+					end.setTime(end.getTime() + repeatInterval);
+					if (start <= now && end >= now) {
+						return true;
+					}
+				}
+				return false;
+			}
+			return acc;
+		}, false);
+		return maintenanceWindowIsActive;
+	}
+
+	/**
+	 * Creates a job handler function for processing jobs.
+	 *
+	 * @returns {Function} An async function that processes a job.
+	 */
+	createJobHandler() {
+		return async (job) => {
+			try {
+				// Get all maintenance windows for this monitor
+				const monitorId = job.data._id;
+				const maintenanceWindowActive = await this.isInMaintenanceWindow(monitorId);
+				// If a maintenance window is active, we're done
+
+				if (maintenanceWindowActive) {
+					this.logger.info({
+						message: `Monitor ${monitorId} is in maintenance window`,
+						service: SERVICE_NAME,
+						method: "createWorker",
+					});
+					return;
+				}
+
+				// Get the current status
+				const networkResponse = await this.networkService.getStatus(job);
+				// Handle status change
+
+				const { monitor, statusChanged, prevStatus } =
+					await this.statusService.updateStatus(networkResponse);
+
+				//If status hasn't changed, we're done
+				if (statusChanged == false) return;
+
+				// if prevStatus is undefined, monitor is resuming, we're done
+				if (prevStatus === undefined) return;
+
+				this.notificationService.handleNotifications({
+					...networkResponse,
+					monitor,
+					prevStatus,
+				});
+			} catch (error) {
+				this.logger.error({
+					message: error.message,
+					service: SERVICE_NAME,
+					method: "createWorker",
+					details: `Error processing job ${job.id}: ${error.message}`,
+					stack: error.stack,
+				});
+			}
+		};
+	}
+
 	/**
 	 * Creates a worker for the queue
 	 * Operations are carried out in the async callback
 	 * @returns {Worker} The newly created worker
 	 */
 	createWorker() {
-		const worker = new this.Worker(
-			QUEUE_NAME,
-			async (job) => {
-				try {
-					// Get all maintenance windows for this monitor
-					const monitorId = job.data._id;
-					const maintenanceWindows =
-						await this.db.getMaintenanceWindowsByMonitorId(monitorId);
-					// Check for active maintenance window:
-					const maintenanceWindowActive = maintenanceWindows.reduce((acc, window) => {
-						if (window.active) {
-							const start = new Date(window.start);
-							const end = new Date(window.end);
-							const now = new Date();
-							const repeatInterval = window.repeat || 0;
-
-							while ((start < now) & (repeatInterval !== 0)) {
-								start.setTime(start.getTime() + repeatInterval);
-								end.setTime(end.getTime() + repeatInterval);
-							}
-
-							if (start < now && end > now) {
-								return true;
-							}
-						}
-						return acc;
-					}, false);
-					if (!maintenanceWindowActive) {
-						await this.networkService.getStatus(job);
-					} else {
-						this.logger.info({
-							message: `Monitor ${monitorId} is in maintenance window`,
-							service: SERVICE_NAME,
-							method: "createWorker",
-						});
-					}
-				} catch (error) {
-					this.logger.error({
-						message: error.message,
-						service: SERVICE_NAME,
-						method: "createWorker",
-						details: `Error processing job ${job.id}: ${error.message}`,
-						stack: error.stack,
-					});
-				}
-			},
-			{
-				connection: this.connection,
-			}
-		);
+		const worker = new this.Worker(QUEUE_NAME, this.createJobHandler(), {
+			connection: this.connection,
+		});
 		return worker;
 	}
 

--- a/Server/service/jobQueue.js
+++ b/Server/service/jobQueue.js
@@ -11,10 +11,15 @@ const SERVICE_NAME = "JobQueue";
  */
 class JobQueue {
 	/**
-	 * Constructs a new JobQueue
-	 * @constructor
-	 * @param {SettingsService} settingsService - The settings service
-	 * @throws {Error}
+	 * @class JobQueue
+	 * @classdesc Manages job queue and workers.
+	 *
+	 * @param {Object} statusService - Service for handling status updates.
+	 * @param {Object} notificationService - Service for handling notifications.
+	 * @param {Object} settingsService - Service for retrieving settings.
+	 * @param {Object} logger - Logger for logging information.
+	 * @param {Function} Queue - Queue constructor.
+	 * @param {Function} Worker - Worker constructor.
 	 */
 	constructor(
 		statusService,
@@ -46,11 +51,18 @@ class JobQueue {
 	}
 
 	/**
-	 * Static factory method to create a JobQueue
-	 * @static
-	 * @async
-	 * @returns {Promise<JobQueue>} - Returns a new JobQueue
+	 * Creates and initializes a JobQueue instance.
 	 *
+	 * @param {Object} db - Database service for accessing monitors.
+	 * @param {Object} networkService - Service for network operations.
+	 * @param {Object} statusService - Service for handling status updates.
+	 * @param {Object} notificationService - Service for handling notifications.
+	 * @param {Object} settingsService - Service for retrieving settings.
+	 * @param {Object} logger - Logger for logging information.
+	 * @param {Function} Queue - Queue constructor.
+	 * @param {Function} Worker - Worker constructor.
+	 * @returns {Promise<JobQueue>} - The initialized JobQueue instance.
+	 * @throws {Error} - Throws an error if initialization fails.
 	 */
 	static async createJobQueue(
 		db,
@@ -89,6 +101,13 @@ class JobQueue {
 		}
 	}
 
+	/**
+	 * Checks if the given monitor is in a maintenance window.
+	 *
+	 * @param {string} monitorId - The ID of the monitor to check.
+	 * @returns {Promise<boolean>} - Returns true if the monitor is in a maintenance window, otherwise false.
+	 * @throws {Error} - Throws an error if the database query fails.
+	 */
 	async isInMaintenanceWindow(monitorId) {
 		const maintenanceWindows = await this.db.getMaintenanceWindowsByMonitorId(monitorId);
 		// Check for active maintenance window:
@@ -286,6 +305,12 @@ class JobQueue {
 		}
 	}
 
+	/**
+	 * Retrieves the statistics of jobs and workers.
+	 *
+	 * @returns {Promise<Object>} - An object containing job statistics and the number of workers.
+	 * @throws {Error} - Throws an error if the job statistics retrieval fails.
+	 */
 	async getJobStats() {
 		try {
 			const jobs = await this.queue.getJobs();
@@ -366,6 +391,12 @@ class JobQueue {
 		}
 	}
 
+	/**
+	 * Retrieves the metrics of the job queue.
+	 *
+	 * @returns {Promise<Object>} - An object containing various job queue metrics.
+	 * @throws {Error} - Throws an error if the metrics retrieval fails.
+	 */
 	async getMetrics() {
 		try {
 			const metrics = {

--- a/Server/service/jobQueue.js
+++ b/Server/service/jobQueue.js
@@ -168,7 +168,7 @@ class JobQueue {
 					await this.statusService.updateStatus(networkResponse);
 
 				//If status hasn't changed, we're done
-				if (statusChanged == false) return;
+				if (statusChanged === false) return;
 
 				// if prevStatus is undefined, monitor is resuming, we're done
 				if (prevStatus === undefined) return;

--- a/Server/service/notificationService.js
+++ b/Server/service/notificationService.js
@@ -1,0 +1,63 @@
+class NotificationService {
+	/**
+	 * Creates an instance of NotificationService.
+	 *
+	 * @param {Object} emailService - The email service used for sending notifications.
+	 * @param {Object} db - The database instance for storing notification data.
+	 * @param {Object} logger - The logger instance for logging activities.
+	 */
+	constructor(emailService, db, logger) {
+		this.SERVICE_NAME = "NotificationService";
+		this.emailService = emailService;
+		this.db = db;
+		this.logger = logger;
+	}
+
+	/**
+	 * Sends an email notification based on the network response.
+	 *
+	 * @param {Object} networkResponse - The response from the network monitor.
+	 * @param {Object} networkResponse.monitor - The monitor object containing details about the monitored service.
+	 * @param {string} networkResponse.monitor.name - The name of the monitor.
+	 * @param {string} networkResponse.monitor.url - The URL of the monitor.
+	 * @param {boolean} networkResponse.status - The current status of the monitor (true for up, false for down).
+	 * @param {boolean} networkResponse.prevStatus - The previous status of the monitor (true for up, false for down).
+	 * @param {string} address - The email address to send the notification to.
+	 */
+	async sendEmail(networkResponse, address) {
+		const { monitor, status, prevStatus } = networkResponse;
+		const template = prevStatus === false ? "serverIsUpTemplate" : "serverIsDownTemplate";
+		const context = { monitor: monitor.name, url: monitor.url };
+		const subject = `Monitor ${monitor.name} is ${status === true ? "up" : "down"}`;
+		this.emailService.buildAndSendEmail(template, context, address, subject);
+	}
+
+	/**
+	 * Handles notifications based on the network response.
+	 *
+	 * @param {Object} networkResponse - The response from the network monitor.
+	 * @param {string} networkResponse.monitorId - The ID of the monitor.
+	 */
+	async handleNotifications(networkResponse) {
+		try {
+			const notifications = await this.db.getNotificationsByMonitorId(
+				networkResponse.monitorId
+			);
+			for (const notification of notifications) {
+				if (notification.type === "email") {
+					this.sendEmail(networkResponse, notification.address);
+				}
+				// Handle other types of notifications here
+			}
+		} catch (error) {
+			this.logger.warn({
+				message: error.message,
+				service: this.SERVICE_NAME,
+				method: "handleNotifications",
+				stack: error.stack,
+			});
+		}
+	}
+}
+
+export default NotificationService;

--- a/Server/service/statusService.js
+++ b/Server/service/statusService.js
@@ -41,7 +41,7 @@ class StatusService {
 
 			const prevStatus = monitor.status;
 			monitor.status = status;
-			monitor.save();
+			await monitor.save();
 
 			return {
 				monitor,

--- a/Server/service/statusService.js
+++ b/Server/service/statusService.js
@@ -8,7 +8,7 @@ class StatusService {
 	constructor(db, logger) {
 		this.db = db;
 		this.logger = logger;
-		this.SERVICE_NAME + "StatusService";
+		this.SERVICE_NAME = "StatusService";
 	}
 
 	/**

--- a/Server/service/statusService.js
+++ b/Server/service/statusService.js
@@ -1,0 +1,139 @@
+class StatusService {
+	/**
+	 * Creates an instance of StatusService.
+	 *
+	 * @param {Object} db - The database instance.
+	 * @param {Object} logger - The logger instance.
+	 */
+	constructor(db, logger) {
+		this.db = db;
+		this.logger = logger;
+		this.SERVICE_NAME + "StatusService";
+	}
+
+	/**
+	 * Updates the status of a monitor based on the network response.
+	 *
+	 * @param {Object} networkResponse - The network response containing monitorId and status.
+	 * @param {string} networkResponse.monitorId - The ID of the monitor.
+	 * @param {string} networkResponse.status - The new status of the monitor.
+	 * @returns {Promise<Object>} - A promise that resolves to an object containing the monitor, statusChanged flag, and previous status if the status changed, or false if an error occurred.
+	 * @returns {Promise<Object>} returnObject - The object returned by the function.
+	 * @returns {Object} returnObject.monitor - The monitor object.
+	 * @returns {boolean} returnObject.statusChanged - Flag indicating if the status has changed.
+	 * @returns {boolean} returnObject.prevStatus - The previous status of the monitor
+	 */
+	updateStatus = async (networkResponse) => {
+		this.insertCheck(networkResponse);
+		try {
+			const { monitorId, status } = networkResponse;
+			const monitor = await this.db.getMonitorById(monitorId);
+			// No change in monitor status, return early
+			if (monitor.status === status) return { statusChanged: false };
+			// Monitor status changed, save prev status and update monitor
+
+			this.logger.info({
+				service: this.SERVICE_NAME,
+				message: `${monitor.name} went from ${monitor.status === true ? "up" : "down"} to ${status === true ? "up" : "down"}`,
+				prevStatus: monitor.status,
+				newStatus: status,
+			});
+
+			const prevStatus = monitor.status;
+			monitor.status = status;
+			monitor.save();
+
+			return {
+				monitor,
+				statusChanged: true,
+				prevStatus: prevStatus,
+			};
+			//
+		} catch (error) {
+			this.logger.error({
+				service: this.SERVICE_NAME,
+				message: error.message,
+				method: "updateStatus",
+				stack: error.stack,
+			});
+			throw error;
+		}
+	};
+
+	/**
+	 * Builds a check object from the network response.
+	 *
+	 * @param {Object} networkResponse - The network response object.
+	 * @param {string} networkResponse.monitorId - The monitor ID.
+	 * @param {string} networkResponse.type - The type of the response.
+	 * @param {string} networkResponse.status - The status of the response.
+	 * @param {number} networkResponse.responseTime - The response time.
+	 * @param {number} networkResponse.code - The status code.
+	 * @param {string} networkResponse.message - The message.
+	 * @param {Object} networkResponse.payload - The payload of the response.
+	 * @returns {Object} The check object.
+	 */
+	buildCheck = (networkResponse) => {
+		const { monitorId, type, status, responseTime, code, message, payload } =
+			networkResponse;
+		const check = {
+			monitorId,
+			status,
+			statusCode: code,
+			responseTime,
+			message,
+		};
+		if (type === "pagespeed") {
+			const categories = payload.lighthouseResult?.categories;
+			const audits = payload.lighthouseResult?.audits;
+			const {
+				"cumulative-layout-shift": cls = 0,
+				"speed-index": si = 0,
+				"first-contentful-paint": fcp = 0,
+				"largest-contentful-paint": lcp = 0,
+				"total-blocking-time": tbt = 0,
+			} = audits;
+			check.accessibility = (categories.accessibility?.score || 0) * 100;
+			check.bestPractices = (categories["best-practices"]?.score || 0) * 100;
+			check.seo = (categories.seo?.score || 0) * 100;
+			check.performance = (categories.performance?.score || 0) * 100;
+			check.audits = { cls, si, fcp, lcp, tbt };
+		}
+		return check;
+	};
+
+	/**
+	 * Inserts a check into the database based on the network response.
+	 *
+	 * @param {Object} networkResponse - The network response object.
+	 * @param {string} networkResponse.monitorId - The monitor ID.
+	 * @param {string} networkResponse.type - The type of the response.
+	 * @param {string} networkResponse.status - The status of the response.
+	 * @param {number} networkResponse.responseTime - The response time.
+	 * @param {number} networkResponse.code - The status code.
+	 * @param {string} networkResponse.message - The message.
+	 * @param {Object} networkResponse.payload - The payload of the response.
+	 * @returns {Promise<void>} A promise that resolves when the check is inserted.
+	 */
+	insertCheck = async (networkResponse) => {
+		try {
+			const operationMap = {
+				http: this.db.createCheck,
+				ping: this.db.createCheck,
+				pagespeed: this.db.createPageSpeedCheck,
+			};
+			const operation = operationMap[networkResponse.type];
+			const check = this.buildCheck(networkResponse);
+			await operation(check);
+		} catch (error) {
+			this.logger.error({
+				message: error.message,
+				service: this.SERVICE_NAME,
+				method: "insertCheck",
+				details: `Error inserting check for monitor: ${networkResponse.monitorId}`,
+				stack: error.stack,
+			});
+		}
+	};
+}
+export default StatusService;

--- a/Server/templates/serverIsDown.mjml
+++ b/Server/templates/serverIsDown.mjml
@@ -1,73 +1,45 @@
 <mjml>
-	<mj-head>
-		<mj-font
-			name="Roboto"
-			href="https://fonts.googleapis.com/css?family=Roboto:300,500"
-		></mj-font>
-		<mj-attributes>
-			<mj-all font-family="Roboto, Helvetica, sans-serif"></mj-all>
-			<mj-text
-				font-weight="300"
-				font-size="16px"
-				color="#616161"
-				line-height="24px"
-			></mj-text>
-			<mj-section padding="0px"></mj-section>
-		</mj-attributes>
-	</mj-head>
-	<mj-body>
-		<mj-section padding="20px 0">
-			<mj-column width="100%">
-				<mj-text
-					align="left"
-					font-size="10px"
-				>
-					Message from BlueWave Uptime Service
-				</mj-text>
-			</mj-column>
-			<mj-column
-				width="45%"
-				padding-top="20px"
-			>
-				<mj-text
-					align="center"
-					font-weight="500"
-					padding="0px"
-					font-size="18px"
-					color="red"
-				>
-					Google.com is down
-				</mj-text>
-				<mj-divider
-					border-width="2px"
-					border-color="#616161"
-				></mj-divider>
-			</mj-column>
-		</mj-section>
-		<mj-section>
-			<mj-column width="100%">
-				<mj-text>
-					<p>Hello {{name}}!</p>
-					<p>
-						We detected an incident on one of your monitors. Your service is currently
-						down. We'll send a message to you once it is up again.
-					</p>
-					<p><b>Monitor name:</b> {{monitor}}</p>
-					<p><b>URL:</b> {{url}}</p>
-					<p><b>Problem:</b> {{problem}}</p>
-					<p><b>Start date:</b> {{startDate}}</p>
-				</mj-text>
-			</mj-column>
-			<mj-column width="100%">
-				<mj-divider
-					border-width="1px"
-					border-color="#E0E0E0"
-				></mj-divider>
-				<mj-button background-color="#1570EF"> View incident details </mj-button>
-				<mj-text font-size="12px">
-					<p>This email was sent by BlueWave Uptime.</p>
-				</mj-text>
-			</mj-column>
-		</mj-section>
-	</mj-body>
+  <mj-head>
+    <mj-font name="Roboto" href="https://fonts.googleapis.com/css?family=Roboto:300,500"></mj-font>
+    <mj-attributes>
+      <mj-all font-family="Roboto, Helvetica, sans-serif"></mj-all>
+      <mj-text font-weight="300" font-size="16px" color="#616161" line-height="24px"></mj-text>
+      <mj-section padding="0px"></mj-section>
+    </mj-attributes>
+  </mj-head>
+  <mj-body>
+    <mj-section padding="20px 0">
+      <mj-column width="100%">
+        <mj-text align="left" font-size="10px">
+          Message from BlueWave Uptime Service
+        </mj-text>
+      </mj-column>
+      <mj-column width="45%" padding-top="20px">
+        <mj-text align="center" font-weight="500" padding="0px" font-size="18px" color="red">
+          Google.com is down
+        </mj-text>
+        <mj-divider border-width="2px" border-color="#616161"></mj-divider>
+      </mj-column>
+    </mj-section>
+    <mj-section>
+      <mj-column width="100%">
+        <mj-text>
+          <p>Hello {{name}}!</p>
+          <p>
+            We detected an incident on one of your monitors. Your service is currently
+            down. We'll send a message to you once it is up again.
+          </p>
+          <p><b>Monitor name:</b> {{monitor}}</p>
+          <p><b>URL:</b> {{url}}</p>
+        </mj-text>
+      </mj-column>
+      <mj-column width="100%">
+        <mj-divider border-width="1px" border-color="#E0E0E0"></mj-divider>
+        <mj-button background-color="#1570EF"> View incident details </mj-button>
+        <mj-text font-size="12px">
+          <p>This email was sent by BlueWave Uptime.</p>
+        </mj-text>
+      </mj-column>
+    </mj-section>
+  </mj-body>
 </mjml>

--- a/Server/templates/serverIsUp.mjml
+++ b/Server/templates/serverIsUp.mjml
@@ -1,72 +1,42 @@
 <mjml>
-	<mj-head>
-		<mj-font
-			name="Roboto"
-			href="https://fonts.googleapis.com/css?family=Roboto:300,500"
-		></mj-font>
-		<mj-attributes>
-			<mj-all font-family="Roboto, Helvetica, sans-serif"></mj-all>
-			<mj-text
-				font-weight="300"
-				font-size="16px"
-				color="#616161"
-				line-height="24px"
-			></mj-text>
-			<mj-section padding="0px"></mj-section>
-		</mj-attributes>
-	</mj-head>
-	<mj-body>
-		<mj-section padding="20px 0">
-			<mj-column width="100%">
-				<mj-text
-					align="left"
-					font-size="10px"
-				>
-					Message from BlueWave Uptime Service
-				</mj-text>
-			</mj-column>
-			<mj-column
-				width="45%"
-				padding-top="20px"
-			>
-				<mj-text
-					align="center"
-					font-weight="500"
-					padding="0px"
-					font-size="18px"
-					color="green"
-				>
-					{{monitor}} is up
-				</mj-text>
-				<mj-divider
-					border-width="2px"
-					border-color="#616161"
-				></mj-divider>
-			</mj-column>
-		</mj-section>
-		<mj-section>
-			<mj-column width="100%">
-				<mj-text>
-					<p>Hello {{name}}!</p>
-					<p>Your latest incident is resolved and your monitored service is up again.</p>
-					<p><b>Monitor name:</b> {{monitor}}</p>
-					<p><b>URL:</b> {{url}}</p>
-					<p><b>Problem:</b> {{problem}}</p>
-					<p><b>Start date:</b> {{startDate}}</p>
-					<p><b>Resolved date:</b> {{resolvedDate}}</p>
-					<p><b>Duration:</b>{{duration}}</p>
-				</mj-text>
-			</mj-column>
-			<mj-column width="100%">
-				<mj-divider
-					border-width="1px"
-					border-color="#E0E0E0"
-				></mj-divider>
-				<mj-button background-color="#1570EF"> View incident details </mj-button>
-				<mj-text font-size="12px">
-					<p>This email was sent by BlueWave Uptime.</p>
-				</mj-text>
-			</mj-column>
-		</mj-section>
-	</mj-body>
+  <mj-head>
+    <mj-font name="Roboto" href="https://fonts.googleapis.com/css?family=Roboto:300,500"></mj-font>
+    <mj-attributes>
+      <mj-all font-family="Roboto, Helvetica, sans-serif"></mj-all>
+      <mj-text font-weight="300" font-size="16px" color="#616161" line-height="24px"></mj-text>
+      <mj-section padding="0px"></mj-section>
+    </mj-attributes>
+  </mj-head>
+  <mj-body>
+    <mj-section padding="20px 0">
+      <mj-column width="100%">
+        <mj-text align="left" font-size="10px">
+          Message from BlueWave Uptime Service
+        </mj-text>
+      </mj-column>
+      <mj-column width="45%" padding-top="20px">
+        <mj-text align="center" font-weight="500" padding="0px" font-size="18px" color="green">
+          {{monitor}} is up
+        </mj-text>
+        <mj-divider border-width="2px" border-color="#616161"></mj-divider>
+      </mj-column>
+    </mj-section>
+    <mj-section>
+      <mj-column width="100%">
+        <mj-text>
+          <p>Hello {{name}}!</p>
+          <p>Your latest incident is resolved and your monitored service is up again.</p>
+          <p><b>Monitor name:</b> {{monitor}}</p>
+          <p><b>URL:</b> {{url}}</p>
+        </mj-text>
+      </mj-column>
+      <mj-column width="100%">
+        <mj-divider border-width="1px" border-color="#E0E0E0"></mj-divider>
+        <mj-button background-color="#1570EF"> View incident details </mj-button>
+        <mj-text font-size="12px">
+          <p>This email was sent by BlueWave Uptime.</p>
+        </mj-text>
+      </mj-column>
+    </mj-section>
+  </mj-body>
 </mjml>

--- a/Server/tests/controllers/monitorController.test.js
+++ b/Server/tests/controllers/monitorController.test.js
@@ -419,12 +419,6 @@ describe("Monitor Controller - createMonitor", () => {
 		expect(next.firstCall.args[0]).to.be.an("error");
 		expect(next.firstCall.args[0].message).to.equal("Job error");
 	});
-	it("should fail validation with empty notifications", async () => {
-		req.body.notifications = [];
-		await createMonitor(req, res, next);
-		expect(next.firstCall.args[0]).to.be.an("error");
-		expect(next.firstCall.args[0].status).to.equal(422);
-	});
 	it("should return success message and data if all operations succeed", async () => {
 		const monitor = { _id: "123", save: sinon.stub() };
 		req.db.createMonitor.returns(monitor);
@@ -789,12 +783,6 @@ describe("Monitor Controller - editMonitor", () => {
 		await editMonitor(req, res, next);
 		expect(next.firstCall.args[0]).to.be.an("error");
 		expect(next.firstCall.args[0].message).to.equal("Add Job error");
-	});
-	it("should fail validation with empty notifications", async () => {
-		req.body.notifications = [];
-		await editMonitor(req, res, next);
-		expect(next.firstCall.args[0]).to.be.an("error");
-		expect(next.firstCall.args[0].status).to.equal(422);
 	});
 	it("should return success message with data if all operations succeed", async () => {
 		const monitor = { _id: "123" };

--- a/Server/tests/services/jobQueue.test.js
+++ b/Server/tests/services/jobQueue.test.js
@@ -526,7 +526,7 @@ describe("JobQueue", () => {
 		});
 	});
 
-	describe("getJobs", async () => {
+	describe("getJobs", () => {
 		it("should return jobs", async () => {
 			const jobQueue = await JobQueue.createJobQueue(
 				db,
@@ -590,7 +590,7 @@ describe("JobQueue", () => {
 		});
 	});
 
-	describe("getJobStats", async () => {
+	describe("getJobStats", () => {
 		it("should return job stats for no jobs", async () => {
 			const jobStats = await jobQueue.getJobStats();
 			expect(jobStats).to.deep.equal({ jobs: [], workers: 5 });

--- a/Server/tests/services/jobQueue.test.js
+++ b/Server/tests/services/jobQueue.test.js
@@ -648,7 +648,7 @@ describe("JobQueue", () => {
 		});
 	});
 
-	describe("addJob", async () => {
+	describe("addJob", () => {
 		it("should add a job to the queue", async () => {
 			jobQueue.addJob("test", { url: "test" });
 			expect(jobQueue.queue.jobs.length).to.equal(1);
@@ -681,7 +681,7 @@ describe("JobQueue", () => {
 			}
 		});
 	});
-	describe("deleteJob", async () => {
+	describe("deleteJob", () => {
 		it("should delete a job from the queue", async () => {
 			jobQueue.getWorkerStats = sinon.stub().returns({ load: 1, jobs: [{}] });
 			jobQueue.scaleWorkers = sinon.stub();

--- a/Server/tests/services/notificationService.test.js
+++ b/Server/tests/services/notificationService.test.js
@@ -1,0 +1,95 @@
+import sinon from "sinon";
+import NotificationService from "../../service/notificationService.js";
+import { expect } from "chai";
+
+describe("NotificationService", () => {
+	let emailService, db, logger, notificationService;
+	beforeEach(() => {
+		db = {
+			getNotificationsByMonitorId: sinon.stub(),
+		};
+		emailService = {
+			buildAndSendEmail: sinon.stub(),
+		};
+		logger = {
+			warn: sinon.stub(),
+		};
+
+		notificationService = new NotificationService(emailService, db, logger);
+	});
+	afterEach(() => {
+		sinon.restore();
+	});
+
+	describe("constructor", () => {
+		it("should create a new instance of NotificationService", () => {
+			expect(notificationService).to.be.an.instanceOf(NotificationService);
+		});
+	});
+
+	describe("sendEmail", async () => {
+		it("should send an email notification with Up Template", async () => {
+			const networkResponse = {
+				monitor: {
+					name: "Test Monitor",
+					url: "http://test.com",
+				},
+				status: true,
+				prevStatus: false,
+			};
+			const address = "test@test.com";
+			await notificationService.sendEmail(networkResponse, address);
+			expect(notificationService.emailService.buildAndSendEmail.calledOnce).to.be.true;
+			expect(
+				notificationService.emailService.buildAndSendEmail.calledWith(
+					"serverIsUpTemplate",
+					{ monitor: "Test Monitor", url: "http://test.com" }
+				)
+			);
+		});
+		it("should send an email notification with Down Template", async () => {
+			const networkResponse = {
+				monitor: {
+					name: "Test Monitor",
+					url: "http://test.com",
+				},
+				status: false,
+				prevStatus: true,
+			};
+			const address = "test@test.com";
+			await notificationService.sendEmail(networkResponse, address);
+			expect(notificationService.emailService.buildAndSendEmail.calledOnce).to.be.true;
+		});
+		it("should send an email notification with Up Template", async () => {
+			const networkResponse = {
+				monitor: {
+					name: "Test Monitor",
+					url: "http://test.com",
+				},
+				status: true,
+				prevStatus: false,
+			};
+			const address = "test@test.com";
+			await notificationService.sendEmail(networkResponse, address);
+			expect(notificationService.emailService.buildAndSendEmail.calledOnce).to.be.true;
+		});
+	});
+
+	describe("handleNotifications", async () => {
+		it("should handle notifications based on the network response", async () => {
+			notificationService.sendEmail = sinon.stub();
+			notificationService.db.getNotificationsByMonitorId.resolves([
+				{ type: "email", address: "www.google.com" },
+			]);
+			await notificationService.handleNotifications({ monitorId: "123" });
+			expect(notificationService.sendEmail.calledOnce).to.be.true;
+		});
+
+		it("should handle an error when getting notifications", async () => {
+			const testError = new Error("Test Error");
+			notificationService.db.getNotificationsByMonitorId.rejects(testError);
+			await notificationService.handleNotifications({ monitorId: "123" });
+			expect(notificationService.logger.warn.calledOnce).to.be.true;
+		});
+	});
+});

--- a/Server/tests/services/statusService.test.js
+++ b/Server/tests/services/statusService.test.js
@@ -1,0 +1,193 @@
+import sinon from "sinon";
+import StatusService from "../../service/statusService.js";
+import { afterEach, describe } from "node:test";
+
+describe("StatusService", () => {
+	let db, logger, statusService;
+	beforeEach(() => {
+		db = {
+			getMonitorById: sinon.stub(),
+			createCheck: sinon.stub(),
+			createPagespeedCheck: sinon.stub(),
+		};
+		logger = {
+			info: sinon.stub(),
+			error: sinon.stub(),
+		};
+		statusService = new StatusService(db, logger);
+	});
+
+	afterEach(() => {
+		sinon.restore();
+	});
+
+	describe("constructor", () => {
+		it("should create an instance of StatusService", () => {
+			expect(statusService).to.be.an.instanceOf(StatusService);
+		});
+	});
+
+	describe("updateStatus", async () => {
+		beforeEach(() => {
+			// statusService.insertCheck = sinon.stub().resolves;
+		});
+		afterEach(() => {
+			sinon.restore();
+		});
+		it("should throw an error if an error occurs", async () => {
+			const error = new Error("Test error");
+			statusService.db.getMonitorById = sinon.stub().throws(error);
+			try {
+				await statusService.updateStatus({ monitorId: "test", status: true });
+			} catch (error) {
+				expect(error.message).to.equal("Test error");
+			}
+			// expect(statusService.insertCheck.calledOnce).to.be.true;
+		});
+		it("should return {statusChanged: false} if status hasn't changed", async () => {
+			statusService.db.getMonitorById = sinon.stub().returns({ status: true });
+			const result = await statusService.updateStatus({
+				monitorId: "test",
+				status: true,
+			});
+			expect(result).to.deep.equal({ statusChanged: false });
+			// expect(statusService.insertCheck.calledOnce).to.be.true;
+		});
+		it("should return {statusChanged: true} if status has changed from down to up", async () => {
+			statusService.db.getMonitorById = sinon
+				.stub()
+				.returns({ status: false, save: sinon.stub() });
+			const result = await statusService.updateStatus({
+				monitorId: "test",
+				status: true,
+			});
+			expect(result.statusChanged).to.be.true;
+			expect(result.monitor.status).to.be.true;
+			expect(result.prevStatus).to.be.false;
+			// expect(statusService.insertCheck.calledOnce).to.be.true;
+		});
+		it("should return {statusChanged: true} if status has changed from up to down", async () => {
+			statusService.db.getMonitorById = sinon
+				.stub()
+				.returns({ status: true, save: sinon.stub() });
+			const result = await statusService.updateStatus({
+				monitorId: "test",
+				status: false,
+			});
+			expect(result.statusChanged).to.be.true;
+			expect(result.monitor.status).to.be.false;
+			expect(result.prevStatus).to.be.true;
+			// expect(statusService.insertCheck.calledOnce).to.be.true;
+		});
+	});
+
+	describe("buildCheck", () => {
+		it("should build a check object", () => {
+			const check = statusService.buildCheck({
+				monitorId: "test",
+				type: "test",
+				status: true,
+				responseTime: 100,
+				code: 200,
+				message: "Test message",
+				payload: { test: "test" },
+			});
+			expect(check.monitorId).to.equal("test");
+			expect(check.status).to.be.true;
+			expect(check.statusCode).to.equal(200);
+			expect(check.responseTime).to.equal(100);
+			expect(check.message).to.equal("Test message");
+		});
+		it("should build a check object for pagespeed type", () => {
+			const check = statusService.buildCheck({
+				monitorId: "test",
+				type: "pagespeed",
+				status: true,
+				responseTime: 100,
+				code: 200,
+				message: "Test message",
+				payload: {
+					lighthouseResult: {
+						categories: {
+							accessibility: { score: 1 },
+							"best-practices": { score: 1 },
+							performance: { score: 1 },
+							seo: { score: 1 },
+						},
+						audits: {
+							"cumulative-layout-shift": { score: 1 },
+							"speed-index": { score: 1 },
+							"first-contentful-paint": { score: 1 },
+							"largest-contentful-paint": { score: 1 },
+							"total-blocking-time": { score: 1 },
+						},
+					},
+				},
+			});
+			expect(check.monitorId).to.equal("test");
+			expect(check.status).to.be.true;
+			expect(check.statusCode).to.equal(200);
+			expect(check.responseTime).to.equal(100);
+			expect(check.message).to.equal("Test message");
+			expect(check.accessibility).to.equal(100);
+			expect(check.bestPractices).to.equal(100);
+			expect(check.performance).to.equal(100);
+			expect(check.seo).to.equal(100);
+			expect(check.audits).to.deep.equal({
+				cls: { score: 1 },
+				si: { score: 1 },
+				fcp: { score: 1 },
+				lcp: { score: 1 },
+				tbt: { score: 1 },
+			});
+		});
+		it("should build a check object for pagespeed type with missing data", () => {
+			const check = statusService.buildCheck({
+				monitorId: "test",
+				type: "pagespeed",
+				status: true,
+				responseTime: 100,
+				code: 200,
+				message: "Test message",
+				payload: {
+					lighthouseResult: {
+						categories: {},
+						audits: {},
+					},
+				},
+			});
+			expect(check.monitorId).to.equal("test");
+			expect(check.status).to.be.true;
+			expect(check.statusCode).to.equal(200);
+			expect(check.responseTime).to.equal(100);
+			expect(check.message).to.equal("Test message");
+			expect(check.accessibility).to.equal(0);
+			expect(check.bestPractices).to.equal(0);
+			expect(check.performance).to.equal(0);
+			expect(check.seo).to.equal(0);
+			expect(check.audits).to.deep.equal({
+				cls: 0,
+				si: 0,
+				fcp: 0,
+				lcp: 0,
+				tbt: 0,
+			});
+		});
+	});
+	describe("insertCheck", () => {
+		it("should log an error if one is thrown", async () => {
+			const testError = new Error("Test error");
+			statusService.db.createCheck = sinon.stub().throws(testError);
+			try {
+				await statusService.insertCheck({ monitorId: "test" });
+			} catch (error) {
+				expect(error.message).to.equal(testError.message);
+			}
+			expect(statusService.logger.error.calledOnce).to.be.true;
+		});
+		it("should insert a check into the database", async () => {
+			await statusService.insertCheck({ monitorId: "test", type: "http" });
+			expect(statusService.db.createCheck.calledOnce).to.be.true;
+		});
+	});
+});

--- a/Server/validation/joi.js
+++ b/Server/validation/joi.js
@@ -234,7 +234,7 @@ const editMonitorBodyValidation = joi.object({
 	name: joi.string(),
 	description: joi.string(),
 	interval: joi.number(),
-	notifications: joi.array().items(joi.object()).min(1),
+	notifications: joi.array().items(joi.object()),
 });
 
 const pauseMonitorParamValidation = joi.object({


### PR DESCRIPTION
This PR refactors the NetworkService class.

The NetworkService class had grown beyond its original inteded purpose of handling network operations to include handling notificaitons and updating monitor status.

These functions have been refactored out to their own specific services for clarity and increased expandability.

This should make the code easier to understand and make our jobs easier when adding new types of monitors or notifications.

- [x] Refactor `NetworkService` to focus on network operations
  - [x] `Network operations` return a standardized response to the `JobQueue` 
- [x] Add a `StatusService` to handle updating monitor status
- [x] Add a `NotificationService` to handle dealing with notifications
- [x] Refactor `JobQueue` to make use of the new services
- [x] Add tests for new services, update tests for `JobQueue` 

It's quite a large PR but I think it's better to deal with this now then wait for the classes to become even more complex.

`NetworkService` is basically an entirely new class, so I would look at it on it's own merit and not worry too much about comparing it to the old `NetworkService`