### PR TITLE
fix/fe/incident-table-typo

### DIFF
--- a/Client/src/Pages/Incidents/IncidentTable/index.jsx
+++ b/Client/src/Pages/Incidents/IncidentTable/index.jsx
@@ -74,7 +74,7 @@ const IncidentTable = ({ monitors, selectedMonitor, filter }) => {
 						sortOrder: "desc",
 						limit: null,
 						dateRange: null,
-						sitler: filter,
+						filter: filter,
 						page: paginationController.page,
 						rowsPerPage: paginationController.rowsPerPage,
 					});


### PR DESCRIPTION
This PR fixes a typo in the incident table which was leading to an unapplied filter

 - [x] "sitler" -> "filter"