### PR TITLE
Feat/be/refactor request pagespeed, resolves #1085

### DIFF
--- a/Server/service/networkService.js
+++ b/Server/service/networkService.js
@@ -126,7 +126,6 @@ class NetworkService {
 			httpResponse.code = code;
 			httpResponse.status = false;
 			httpResponse.message = this.http.STATUS_CODES[code] || "Network Error";
-
 			return httpResponse;
 		}
 		httpResponse.status = true;
@@ -153,31 +152,10 @@ class NetworkService {
 	 */
 	async requestPagespeed(job) {
 		const url = job.data.url;
-		const { response, responseTime, error } = await this.timeRequest(() =>
-			this.axios.get(
-				`https://pagespeedonline.googleapis.com/pagespeedonline/v5/runPagespeed?url=${url}&category=seo&category=accessibility&category=best-practices&category=performance`
-			)
-		);
-
-		const pagespeedResponse = {
-			monitorId: job.data._id,
-			type: job.data.type,
-			responseTime,
-			payload: response?.data,
-		};
-
-		if (error) {
-			const code = error.response?.status || this.NETWORK_ERROR;
-			pagespeedResponse.code = code;
-			pagespeedResponse.status = false;
-			pagespeedResponse.message = this.http.STATUS_CODES[code] || "Network Error";
-			return pagespeedResponse;
-		}
-
-		pagespeedResponse.status = true;
-		pagespeedResponse.code = response.status;
-		pagespeedResponse.message = this.http.STATUS_CODES[response.status];
-		return pagespeedResponse;
+		const updatedJob = { ...job };
+		const pagespeedUrl = `https://pagespeedonline.googleapis.com/pagespeedonline/v5/runPagespeed?url=${url}&category=seo&category=accessibility&category=best-practices&category=performance`;
+		updatedJob.data.url = pagespeedUrl;
+		return this.requestHttp(updatedJob);
 	}
 
 	async requestHardware(job) {

--- a/Server/service/statusService.js
+++ b/Server/service/statusService.js
@@ -101,10 +101,10 @@ class StatusService {
 		}
 
 		if (type === "hardware") {
-			check.cpu = payload.cpu;
-			check.memory = payload.memory;
-			check.disk = payload.disk;
-			check.host = payload.host;
+			check.cpu = payload?.cpu ?? {};
+			check.memory = payload?.memory ?? {};
+			check.disk = payload?.disk ?? {};
+			check.host = payload?.host ?? {};
 		}
 		return check;
 	};


### PR DESCRIPTION
This PR refactors the `requestPagespeed` method of the `NetworkService` class.

The method was identical to `requestHttp` except for request URL, so it duplicated most of requestHttp's code.

- [x] Refactor `requestPagespeed` to call `requestHttp` with an updated job.  If `requestPagespeed`'s functionality ever changes the method is still there and can be refactored again if needed.

- [x] Add safety checks to hardware monitor value access