### PR TITLE
fix/devlops/base-api-url

### DIFF
--- a/Docker/prod/docker-compose.yaml
+++ b/Docker/prod/docker-compose.yaml
@@ -2,7 +2,7 @@ services:
   client:
     image: uptime_client:latest
     environment:
-      UPTIME_APP_API_BASE_URL: "http://localhost:5000/api/v1"
+      UPTIME_APP_API_BASE_URL: "https://uptime-demo.bluewavelabs.ca/api/v1"
     ports:
       - "80:80"
       - "443:443"


### PR DESCRIPTION
This PR ammends the base API url in the docker-compose file.  It was mistakenly pointing to localhost

- [x] Ammend production base API address