### PR TITLE
Feat/be/graceful shutdown

### DIFF
--- a/Server/index.js
+++ b/Server/index.js
@@ -45,6 +45,7 @@ import NotificationService from "./service/notificationService.js";
 import db from "./db/mongo/MongoDB.js";
 const SERVICE_NAME = "Server";
 
+let isShuttingDown = false;
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
@@ -141,6 +142,10 @@ const startApp = async () => {
 	);
 
 	const shutdown = async () => {
+		if (isShuttingDown) {
+			return;
+		}
+		isShuttingDown = true;
 		logger.info({ message: "Attempting graceful shutdown" });
 		setTimeout(() => {
 			logger.error({
@@ -149,7 +154,7 @@ const startApp = async () => {
 				method: "shutdown",
 			});
 			process.exit(1);
-		}, 10000);
+		}, 2000);
 		try {
 			server.close();
 			await jobQueue.obliterate();

--- a/Server/index.js
+++ b/Server/index.js
@@ -44,6 +44,7 @@ import NotificationService from "./service/notificationService.js";
 
 import db from "./db/mongo/MongoDB.js";
 const SERVICE_NAME = "Server";
+const SHUTDOWN_TIMEOUT = 0;
 
 let isShuttingDown = false;
 const __filename = fileURLToPath(import.meta.url);
@@ -154,7 +155,7 @@ const startApp = async () => {
 				method: "shutdown",
 			});
 			process.exit(1);
-		}, 2000);
+		}, SHUTDOWN_TIMEOUT);
 		try {
 			server.close();
 			await jobQueue.obliterate();

--- a/Server/service/jobQueue.js
+++ b/Server/service/jobQueue.js
@@ -36,10 +36,10 @@ class JobQueue {
 			host: redisHost,
 			port: redisPort,
 		};
-		this.connection = connection;
 		this.queue = new Queue(QUEUE_NAME, {
 			connection,
 		});
+		this.connection = connection;
 		this.workers = [];
 		this.db = null;
 		this.networkService = null;
@@ -406,9 +406,6 @@ class JobQueue {
 				delayed: await this.queue.getDelayedCount(),
 				repeatableJobs: (await this.queue.getRepeatableJobs()).length,
 			};
-			this.logger.info({
-				message: metrics,
-			});
 			return metrics;
 		} catch (error) {
 			this.logger.error({
@@ -424,17 +421,33 @@ class JobQueue {
 	 * @async
 	 * @returns {Promise<boolean>} - Returns true if obliteration is successful
 	 */
+
 	async obliterate() {
 		try {
-			let metrics = await this.getMetrics();
-			this.logger.info({ message: metrics });
+			this.logger.info({ message: "Attempting to obliterate job queue..." });
 			await this.queue.pause();
 			const jobs = await this.getJobs();
 
+			// Stop currently active jobs
+			const redisClient = await this.queue.client;
+			const activeJobs = await this.queue.getJobs(["active"]);
+			if (activeJobs.length !== 0) {
+				this.logger.info({ message: "Attempting to stop active jobs..." });
+			}
+			await Promise.all(
+				activeJobs.map(async (job) => {
+					await redisClient.del(`${this.queue.toKey(job.id)}:lock`);
+					await job.remove();
+				})
+			);
+
+			// Remove all repeatable jobs
 			for (const job of jobs) {
 				await this.queue.removeRepeatableByKey(job.key);
 				await this.queue.remove(job.id);
 			}
+
+			// Close workers
 			await Promise.all(
 				this.workers.map(async (worker) => {
 					await worker.close();
@@ -442,9 +455,13 @@ class JobQueue {
 			);
 
 			await this.queue.obliterate();
-			metrics = await this.getMetrics();
-			this.logger.info({ message: metrics });
-			this.logger.info({ message: successMessages.JOB_QUEUE_OBLITERATE });
+			const metrics = await this.getMetrics();
+			this.logger.info({
+				message: successMessages.JOB_QUEUE_OBLITERATE,
+				service: SERVICE_NAME,
+				method: "obliterate",
+				details: metrics,
+			});
 			return true;
 		} catch (error) {
 			error.service === undefined ? (error.service = SERVICE_NAME) : null;

--- a/Server/service/jobQueue.js
+++ b/Server/service/jobQueue.js
@@ -428,19 +428,6 @@ class JobQueue {
 			await this.queue.pause();
 			const jobs = await this.getJobs();
 
-			// Stop currently active jobs
-			const redisClient = await this.queue.client;
-			const activeJobs = await this.queue.getJobs(["active"]);
-			if (activeJobs.length !== 0) {
-				this.logger.info({ message: "Attempting to stop active jobs..." });
-			}
-			await Promise.all(
-				activeJobs.map(async (job) => {
-					await redisClient.del(`${this.queue.toKey(job.id)}:lock`);
-					await job.remove();
-				})
-			);
-
 			// Remove all repeatable jobs
 			for (const job of jobs) {
 				await this.queue.removeRepeatableByKey(job.key);

--- a/Server/utils/logger.js
+++ b/Server/utils/logger.js
@@ -7,6 +7,10 @@ class Logger {
 				if (message instanceof Object) {
 					message = JSON.stringify(message, null, 2);
 				}
+
+				if (details instanceof Object) {
+					details = JSON.stringify(details, null, 2);
+				}
 				let msg = `${timestamp} ${level}:`;
 				service && (msg += ` [${service}]`);
 				method && (msg += `(${method})`);


### PR DESCRIPTION
This PR improves graceful shutdown for the server

- [x] Close server on kill/interupt signal
- [x] Add a timeout to force the server to shutdown if graceful shutdown fails
- [x] Remove excessive logging in obliterate method
- [ ] Figure out how to remove active jobs.  They are locked once they are started and are difficult to stop.  This is mostly an issue for the pagespeed API calls which can take a long time to finish.   