### PR TITLE
Feat/be/uptime percentage stats, references #1115

### DIFF
--- a/Server/.nycrc
+++ b/Server/.nycrc
@@ -1,6 +1,11 @@
 {
 	"all": true,
-	"include": ["controllers/*.js", "utils/*.js", "service/*.js"],
+	"include": [
+		"controllers/*.js",
+		"utils/*.js",
+		"service/*.js",
+		"db/mongo/modules/monitorModule.js"
+	],
 	"exclude": ["**/*.test.js"],
 	"reporter": ["html", "text", "lcov"],
 	"sourceMap": false,

--- a/Server/controllers/monitorController.js
+++ b/Server/controllers/monitorController.js
@@ -46,6 +46,28 @@ const getAllMonitors = async (req, res, next) => {
 };
 
 /**
+ * Returns all monitors with uptime stats for 1,7,30, and 90 days
+ * @async
+ * @param {Express.Request} req
+ * @param {Express.Response} res
+ * @param {function} next
+ * @returns {Promise<Express.Response>}
+ * @throws {Error}
+ */
+const getAllMonitorsWithUptimeStats = async (req, res, next) => {
+	try {
+		const monitors = await req.db.getAllMonitorsWithUptimeStats();
+		return res.status(200).json({
+			success: true,
+			msg: successMessages.MONITOR_GET_ALL,
+			data: monitors,
+		});
+	} catch (error) {
+		next(handleError(error, SERVICE_NAME, "getAllMonitorsWithUptimeStats"));
+	}
+};
+
+/**
  * Returns monitor stats for monitor with matching ID
  * @async
  * @param {Express.Request} req
@@ -495,6 +517,7 @@ const addDemoMonitors = async (req, res, next) => {
 
 export {
 	getAllMonitors,
+	getAllMonitorsWithUptimeStats,
 	getMonitorStatsById,
 	getMonitorCertificate,
 	getMonitorById,

--- a/Server/db/mongo/MongoDB.js
+++ b/Server/db/mongo/MongoDB.js
@@ -99,6 +99,7 @@ import {
 
 import {
 	getAllMonitors,
+	getAllMonitorsWithUptimeStats,
 	getMonitorStatsById,
 	getMonitorById,
 	getMonitorsAndSummaryByTeamId,
@@ -187,6 +188,7 @@ export default {
 	resetPassword,
 	checkSuperadmin,
 	getAllMonitors,
+	getAllMonitorsWithUptimeStats,
 	getMonitorStatsById,
 	getMonitorById,
 	getMonitorsAndSummaryByTeamId,

--- a/Server/db/mongo/modules/monitorModule.js
+++ b/Server/db/mongo/modules/monitorModule.js
@@ -406,7 +406,7 @@ const getMonitorsByTeamId = async (req, res) => {
 			filter,
 			field,
 			order,
-		} = req.query || {};
+		} = req.query;
 
 		const monitorQuery = { teamId: req.params.teamId };
 
@@ -441,10 +441,6 @@ const getMonitorsByTeamId = async (req, res) => {
 		// Map each monitor to include its associated checks
 		const monitorsWithChecks = await Promise.all(
 			monitors.map(async (monitor) => {
-				if (status !== undefined) {
-					checksQuery.status = status;
-				}
-
 				let model = CHECK_MODEL_LOOKUP[monitor.type];
 
 				// Checks are order newest -> oldest
@@ -486,7 +482,6 @@ const createMonitor = async (req, res) => {
 		// Remove notifications fom monitor as they aren't needed here
 		monitor.notifications = undefined;
 		await monitor.save();
-		console.log(monitor);
 		return monitor;
 	} catch (error) {
 		error.service = SERVICE_NAME;

--- a/Server/db/mongo/modules/monitorModule.js
+++ b/Server/db/mongo/modules/monitorModule.js
@@ -52,7 +52,6 @@ const calculateUptimeDuration = (checks) => {
 	if (!checks || checks.length === 0) {
 		return 0;
 	}
-
 	const latestCheck = new Date(checks[0].createdAt);
 	let latestDownCheck = 0;
 
@@ -439,7 +438,6 @@ const getMonitorsByTeamId = async (req, res) => {
 		if (limit === "-1") {
 			return { monitors, monitorCount };
 		}
-
 		// Map each monitor to include its associated checks
 		const monitorsWithChecks = await Promise.all(
 			monitors.map(async (monitor) => {
@@ -488,6 +486,7 @@ const createMonitor = async (req, res) => {
 		// Remove notifications fom monitor as they aren't needed here
 		monitor.notifications = undefined;
 		await monitor.save();
+		console.log(monitor);
 		return monitor;
 	} catch (error) {
 		error.service = SERVICE_NAME;

--- a/Server/openapi.json
+++ b/Server/openapi.json
@@ -22,16 +22,12 @@
 			"variables": {
 				"PORT": {
 					"description": "API Port",
-					"enum": [
-						"5000"
-					],
+					"enum": ["5000"],
 					"default": "5000"
 				},
 				"API_PATH": {
 					"description": "API Base Path",
-					"enum": [
-						"api/v1"
-					],
+					"enum": ["api/v1"],
 					"default": "api/v1"
 				}
 			}
@@ -42,9 +38,7 @@
 			"variables": {
 				"API_PATH": {
 					"description": "API Base Path",
-					"enum": [
-						"api/v1"
-					],
+					"enum": ["api/v1"],
 					"default": "api/v1"
 				}
 			}
@@ -55,16 +49,12 @@
 			"variables": {
 				"PORT": {
 					"description": "API Port",
-					"enum": [
-						"5000"
-					],
+					"enum": ["5000"],
 					"default": "5000"
 				},
 				"API_PATH": {
 					"description": "API Base Path",
-					"enum": [
-						"api/v1"
-					],
+					"enum": ["api/v1"],
 					"default": "api/v1"
 				}
 			}
@@ -99,9 +89,7 @@
 	"paths": {
 		"/auth/register": {
 			"post": {
-				"tags": [
-					"auth"
-				],
+				"tags": ["auth"],
 				"description": "Register a new user",
 				"requestBody": {
 					"content": {
@@ -137,23 +125,8 @@
 									},
 									"role": {
 										"type": "array",
-										"enum": [
-											[
-												"user"
-											],
-											[
-												"admin"
-											],
-											[
-												"superadmin"
-											],
-											[
-												"Demo"
-											]
-										],
-										"default": [
-											"superadmin"
-										]
+										"enum": [["user"], ["admin"], ["superadmin"], ["Demo"]],
+										"default": ["superadmin"]
 									},
 									"teamId": {
 										"type": "string",
@@ -200,19 +173,14 @@
 		},
 		"/auth/login": {
 			"post": {
-				"tags": [
-					"auth"
-				],
+				"tags": ["auth"],
 				"description": "Login with credentials",
 				"requestBody": {
 					"content": {
 						"application/json": {
 							"schema": {
 								"type": "object",
-								"required": [
-									"email",
-									"password"
-								],
+								"required": ["email", "password"],
 								"properties": {
 									"email": {
 										"type": "string",
@@ -263,9 +231,7 @@
 		},
 		"/auth/refresh": {
 			"post": {
-				"tags": [
-					"auth"
-				],
+				"tags": ["auth"],
 				"description": "Generates a new auth token if the refresh token is valid.",
 				"requestBody": {
 					"content": {
@@ -334,9 +300,7 @@
 		},
 		"/auth/user/{userId}": {
 			"put": {
-				"tags": [
-					"auth"
-				],
+				"tags": ["auth"],
 				"description": "Change user information",
 				"parameters": [
 					{
@@ -397,9 +361,7 @@
 				]
 			},
 			"delete": {
-				"tags": [
-					"auth"
-				],
+				"tags": ["auth"],
 				"description": "Delete user",
 				"parameters": [
 					{
@@ -452,9 +414,7 @@
 		},
 		"/auth/users/superadmin": {
 			"get": {
-				"tags": [
-					"auth"
-				],
+				"tags": ["auth"],
 				"description": "Checks to see if an admin account exists",
 				"responses": {
 					"200": {
@@ -497,9 +457,7 @@
 		},
 		"/auth/users": {
 			"get": {
-				"tags": [
-					"auth"
-				],
+				"tags": ["auth"],
 				"description": "Get all users",
 				"responses": {
 					"200": {
@@ -542,18 +500,14 @@
 		},
 		"/auth/recovery/request": {
 			"post": {
-				"tags": [
-					"auth"
-				],
+				"tags": ["auth"],
 				"description": "Request a recovery token",
 				"requestBody": {
 					"content": {
 						"application/json": {
 							"schema": {
 								"type": "object",
-								"required": [
-									"email"
-								],
+								"required": ["email"],
 								"properties": {
 									"email": {
 										"type": "string",
@@ -600,18 +554,14 @@
 		},
 		"/auth/recovery/validate": {
 			"post": {
-				"tags": [
-					"auth"
-				],
+				"tags": ["auth"],
 				"description": "Validate recovery token",
 				"requestBody": {
 					"content": {
 						"application/json": {
 							"schema": {
 								"type": "object",
-								"required": [
-									"recoveryToken"
-								],
+								"required": ["recoveryToken"],
 								"properties": {
 									"recoveryToken": {
 										"type": "string"
@@ -657,19 +607,14 @@
 		},
 		"/auth/recovery/reset": {
 			"post": {
-				"tags": [
-					"auth"
-				],
+				"tags": ["auth"],
 				"description": "Password reset",
 				"requestBody": {
 					"content": {
 						"application/json": {
 							"schema": {
 								"type": "object",
-								"required": [
-									"recoveryToken",
-									"password"
-								],
+								"required": ["recoveryToken", "password"],
 								"properties": {
 									"recoveryToken": {
 										"type": "string"
@@ -718,19 +663,14 @@
 		},
 		"/invite": {
 			"post": {
-				"tags": [
-					"invite"
-				],
+				"tags": ["invite"],
 				"description": "Request an invitation",
 				"requestBody": {
 					"content": {
 						"application/json": {
 							"schema": {
 								"type": "object",
-								"required": [
-									"email",
-									"role"
-								],
+								"required": ["email", "role"],
 								"properties": {
 									"email": {
 										"type": "string"
@@ -784,18 +724,14 @@
 		},
 		"/invite/verify": {
 			"post": {
-				"tags": [
-					"invite"
-				],
+				"tags": ["invite"],
 				"description": "Request an invitation",
 				"requestBody": {
 					"content": {
 						"application/json": {
 							"schema": {
 								"type": "object",
-								"required": [
-									"token"
-								],
+								"required": ["token"],
 								"properties": {
 									"token": {
 										"type": "string"
@@ -846,9 +782,7 @@
 		},
 		"/monitors": {
 			"get": {
-				"tags": [
-					"monitors"
-				],
+				"tags": ["monitors"],
 				"description": "Get all monitors",
 				"responses": {
 					"200": {
@@ -889,9 +823,7 @@
 				]
 			},
 			"post": {
-				"tags": [
-					"monitors"
-				],
+				"tags": ["monitors"],
 				"description": "Create a new monitor",
 				"requestBody": {
 					"content": {
@@ -941,9 +873,7 @@
 				]
 			},
 			"delete": {
-				"tags": [
-					"monitors"
-				],
+				"tags": ["monitors"],
 				"description": "Delete all monitors",
 				"responses": {
 					"200": {
@@ -984,11 +914,42 @@
 				]
 			}
 		},
+		"/monitors/uptime": {
+			"get": {
+				"tags": ["monitors"],
+				"description": "Get all monitors with uptime stats for 1, 7, 30, and 90 days",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/SuccessResponse"
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Internal Server Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ErrorResponse"
+								}
+							}
+						}
+					}
+				},
+				"security": [
+					{
+						"bearerAuth": []
+					}
+				]
+			}
+		},
 		"/monitors/resolution/url": {
 			"get": {
-				"tags": [
-					"monitors"
-				],
+				"tags": ["monitors"],
 				"description": "Check DNS resolution for a given URL",
 				"parameters": [
 					{
@@ -1053,9 +1014,7 @@
 		},
 		"/monitors/{monitorId}": {
 			"get": {
-				"tags": [
-					"monitors"
-				],
+				"tags": ["monitors"],
 				"description": "Get monitor by id",
 				"parameters": [
 					{
@@ -1106,9 +1065,7 @@
 				]
 			},
 			"put": {
-				"tags": [
-					"monitors"
-				],
+				"tags": ["monitors"],
 				"description": "Update monitor by id",
 				"parameters": [
 					{
@@ -1168,9 +1125,7 @@
 				]
 			},
 			"delete": {
-				"tags": [
-					"monitors"
-				],
+				"tags": ["monitors"],
 				"description": "Delete monitor by id",
 				"parameters": [
 					{
@@ -1223,9 +1178,7 @@
 		},
 		"/monitors/stats/{monitorId}": {
 			"get": {
-				"tags": [
-					"monitors"
-				],
+				"tags": ["monitors"],
 				"description": "Get monitor stats",
 				"parameters": [
 					{
@@ -1278,9 +1231,7 @@
 		},
 		"/monitors/certificate/{monitorId}": {
 			"get": {
-				"tags": [
-					"monitors"
-				],
+				"tags": ["monitors"],
 				"description": "Get monitor certificate",
 				"parameters": [
 					{
@@ -1333,9 +1284,7 @@
 		},
 		"/monitors/team/summary/{teamId}": {
 			"get": {
-				"tags": [
-					"monitors"
-				],
+				"tags": ["monitors"],
 				"description": "Get monitors and summary by teamId",
 				"parameters": [
 					{
@@ -1352,11 +1301,7 @@
 						"required": false,
 						"schema": {
 							"type": "array",
-							"enum": [
-								"http",
-								"ping",
-								"pagespeed"
-							]
+							"enum": ["http", "ping", "pagespeed"]
 						}
 					}
 				],
@@ -1401,9 +1346,7 @@
 		},
 		"/monitors/team/{teamId}": {
 			"get": {
-				"tags": [
-					"monitors"
-				],
+				"tags": ["monitors"],
 				"description": "Get monitors by teamId",
 				"parameters": [
 					{
@@ -1430,10 +1373,7 @@
 						"required": false,
 						"schema": {
 							"type": "string",
-							"enum": [
-								"asc",
-								"desc"
-							]
+							"enum": ["asc", "desc"]
 						}
 					},
 					{
@@ -1452,11 +1392,7 @@
 						"required": false,
 						"schema": {
 							"type": "string",
-							"enum": [
-								"http",
-								"ping",
-								"pagespeed"
-							]
+							"enum": ["http", "ping", "pagespeed"]
 						}
 					},
 					{
@@ -1500,11 +1436,7 @@
 						"required": false,
 						"schema": {
 							"type": "string",
-							"enum": [
-								"http",
-								"ping",
-								"pagespeed"
-							]
+							"enum": ["http", "ping", "pagespeed"]
 						}
 					}
 				],
@@ -1549,9 +1481,7 @@
 		},
 		"/monitors/pause/{monitorId}": {
 			"post": {
-				"tags": [
-					"monitors"
-				],
+				"tags": ["monitors"],
 				"description": "Pause monitor",
 				"parameters": [
 					{
@@ -1604,9 +1534,7 @@
 		},
 		"/monitors/demo": {
 			"post": {
-				"tags": [
-					"monitors"
-				],
+				"tags": ["monitors"],
 				"description": "Create a demo monitor",
 				"requestBody": {
 					"content": {
@@ -1658,9 +1586,7 @@
 		},
 		"/checks/{monitorId}": {
 			"get": {
-				"tags": [
-					"checks"
-				],
+				"tags": ["checks"],
 				"description": "Get all checks for a monitor",
 				"parameters": [
 					{
@@ -1711,9 +1637,7 @@
 				]
 			},
 			"post": {
-				"tags": [
-					"checks"
-				],
+				"tags": ["checks"],
 				"description": "Create a new check",
 				"parameters": [
 					{
@@ -1773,9 +1697,7 @@
 				]
 			},
 			"delete": {
-				"tags": [
-					"checks"
-				],
+				"tags": ["checks"],
 				"description": "Delete all checks for a monitor",
 				"parameters": [
 					{
@@ -1828,9 +1750,7 @@
 		},
 		"/checks/team/{teamId}": {
 			"get": {
-				"tags": [
-					"checks"
-				],
+				"tags": ["checks"],
 				"description": "Get all checks for a team",
 				"parameters": [
 					{
@@ -1881,9 +1801,7 @@
 				]
 			},
 			"delete": {
-				"tags": [
-					"checks"
-				],
+				"tags": ["checks"],
 				"description": "Delete all checks for a team",
 				"parameters": [
 					{
@@ -1936,9 +1854,7 @@
 		},
 		"/checks/team/ttl": {
 			"put": {
-				"tags": [
-					"checks"
-				],
+				"tags": ["checks"],
 				"description": "Update check TTL",
 				"requestBody": {
 					"content": {
@@ -1990,9 +1906,7 @@
 		},
 		"/maintenance-window/monitor/{monitorId}": {
 			"get": {
-				"tags": [
-					"maintenance-window"
-				],
+				"tags": ["maintenance-window"],
 				"description": "Get maintenance window for monitor",
 				"parameters": [
 					{
@@ -2043,9 +1957,7 @@
 				]
 			},
 			"post": {
-				"tags": [
-					"maintenance-window"
-				],
+				"tags": ["maintenance-window"],
 				"description": "Create maintenance window for monitor",
 				"parameters": [
 					{
@@ -2107,9 +2019,7 @@
 		},
 		"/maintenance-window/user/{userId}": {
 			"get": {
-				"tags": [
-					"maintenance-window"
-				],
+				"tags": ["maintenance-window"],
 				"description": "Get maintenance window for user",
 				"parameters": [
 					{
@@ -2162,9 +2072,7 @@
 		},
 		"/queue/jobs": {
 			"get": {
-				"tags": [
-					"queue"
-				],
+				"tags": ["queue"],
 				"description": "Get all jobs in queue",
 				"responses": {
 					"200": {
@@ -2205,9 +2113,7 @@
 				]
 			},
 			"post": {
-				"tags": [
-					"queue"
-				],
+				"tags": ["queue"],
 				"description": "Create a new job.  Useful for testing scaling workers",
 				"responses": {
 					"200": {
@@ -2250,9 +2156,7 @@
 		},
 		"/queue/metrics": {
 			"get": {
-				"tags": [
-					"queue"
-				],
+				"tags": ["queue"],
 				"description": "Get queue metrics",
 				"responses": {
 					"200": {
@@ -2295,9 +2199,7 @@
 		},
 		"/queue/obliterate": {
 			"post": {
-				"tags": [
-					"queue"
-				],
+				"tags": ["queue"],
 				"description": "Obliterate job queue",
 				"responses": {
 					"200": {
@@ -2377,14 +2279,7 @@
 			},
 			"UserUpdateRequest": {
 				"type": "object",
-				"required": [
-					"firstName",
-					"lastName",
-					"email",
-					"password",
-					"role",
-					"teamId"
-				],
+				"required": ["firstName", "lastName", "email", "password", "role", "teamId"],
 				"properties": {
 					"firstName": {
 						"type": "string"
@@ -2406,23 +2301,8 @@
 					},
 					"role": {
 						"type": "array",
-						"enum": [
-							[
-								"user"
-							],
-							[
-								"admin"
-							],
-							[
-								"superadmin"
-							],
-							[
-								"Demo"
-							]
-						],
-						"default": [
-							"superadmin"
-						]
+						"enum": [["user"], ["admin"], ["superadmin"], ["Demo"]],
+						"default": ["superadmin"]
 					},
 					"deleteProfileImage": {
 						"type": "boolean"
@@ -2431,14 +2311,7 @@
 			},
 			"CreateMonitorBody": {
 				"type": "object",
-				"required": [
-					"userId",
-					"teamId",
-					"name",
-					"description",
-					"type",
-					"url"
-				],
+				"required": ["userId", "teamId", "name", "description", "type", "url"],
 				"properties": {
 					"_id": {
 						"type": "string"
@@ -2457,11 +2330,7 @@
 					},
 					"type": {
 						"type": "string",
-						"enum": [
-							"http",
-							"ping",
-							"pagespeed"
-						]
+						"enum": ["http", "ping", "pagespeed"]
 					},
 					"url": {
 						"type": "string"
@@ -2502,13 +2371,7 @@
 			},
 			"CreateCheckBody": {
 				"type": "object",
-				"required": [
-					"monitorId",
-					"status",
-					"responseTime",
-					"statusCode",
-					"message"
-				],
+				"required": ["monitorId", "status", "responseTime", "statusCode", "message"],
 				"properties": {
 					"monitorId": {
 						"type": "string"
@@ -2529,9 +2392,7 @@
 			},
 			"UpdateCheckTTLBody": {
 				"type": "object",
-				"required": [
-					"ttl"
-				],
+				"required": ["ttl"],
 				"properties": {
 					"ttl": {
 						"type": "integer"
@@ -2540,13 +2401,7 @@
 			},
 			"CreateMaintenanceWindowBody": {
 				"type": "object",
-				"required": [
-					"userId",
-					"active",
-					"oneTime",
-					"start",
-					"end"
-				],
+				"required": ["userId", "active", "oneTime", "start", "end"],
 				"properties": {
 					"userId": {
 						"type": "string"

--- a/Server/routes/monitorRoute.js
+++ b/Server/routes/monitorRoute.js
@@ -1,18 +1,19 @@
 import { Router } from "express";
 import {
-  getAllMonitors,
-  getMonitorStatsById,
-  getMonitorCertificate,
-  getMonitorById,
-  getMonitorsAndSummaryByTeamId,
-  getMonitorsByTeamId,
-  createMonitor,
-  checkEndpointResolution,
-  deleteMonitor,
-  deleteAllMonitors,
-  editMonitor,
-  pauseMonitor,
-  addDemoMonitors,
+	getAllMonitors,
+	getAllMonitorsWithUptimeStats,
+	getMonitorStatsById,
+	getMonitorCertificate,
+	getMonitorById,
+	getMonitorsAndSummaryByTeamId,
+	getMonitorsByTeamId,
+	createMonitor,
+	checkEndpointResolution,
+	deleteMonitor,
+	deleteAllMonitors,
+	editMonitor,
+	pauseMonitor,
+	addDemoMonitors,
 } from "../controllers/monitorController.js";
 import { isAllowed } from "../middleware/isAllowed.js";
 import { fetchMonitorCertificate } from "../controllers/controllerUtils.js";
@@ -20,25 +21,22 @@ import { fetchMonitorCertificate } from "../controllers/controllerUtils.js";
 const router = Router();
 
 router.get("/", getAllMonitors);
+router.get("/uptime", getAllMonitorsWithUptimeStats);
 router.get("/stats/:monitorId", getMonitorStatsById);
 router.get("/certificate/:monitorId", (req, res, next) => {
-  getMonitorCertificate(req, res, next, fetchMonitorCertificate);
+	getMonitorCertificate(req, res, next, fetchMonitorCertificate);
 });
 router.get("/:monitorId", getMonitorById);
 router.get("/team/summary/:teamId", getMonitorsAndSummaryByTeamId);
 router.get("/team/:teamId", getMonitorsByTeamId);
 
 router.get(
-  "/resolution/url",
-  isAllowed(["admin", "superadmin"]),
-  checkEndpointResolution
-)
-
-router.delete(
-  "/:monitorId",
-  isAllowed(["admin", "superadmin"]),
-  deleteMonitor
+	"/resolution/url",
+	isAllowed(["admin", "superadmin"]),
+	checkEndpointResolution
 );
+
+router.delete("/:monitorId", isAllowed(["admin", "superadmin"]), deleteMonitor);
 
 router.post("/", isAllowed(["admin", "superadmin"]), createMonitor);
 

--- a/Server/tests/controllers/monitorController.test.js
+++ b/Server/tests/controllers/monitorController.test.js
@@ -1,5 +1,6 @@
 import {
 	getAllMonitors,
+	getAllMonitorsWithUptimeStats,
 	getMonitorStatsById,
 	getMonitorCertificate,
 	getMonitorById,
@@ -51,6 +52,47 @@ describe("Monitor Controller - getAllMonitors", () => {
 		const data = [{ monitor: "data" }];
 		req.db.getAllMonitors.returns(data);
 		await getAllMonitors(req, res, next);
+		expect(res.status.firstCall.args[0]).to.equal(200);
+		expect(
+			res.json.calledOnceWith({
+				success: true,
+				msg: successMessages.MONITOR_GET_ALL,
+				data: data,
+			})
+		).to.be.true;
+	});
+});
+describe("Monitor Controller - getAllMonitorsWithUptimeStats", () => {
+	let req, res, next;
+	beforeEach(() => {
+		req = {
+			params: {},
+			query: {},
+			body: {},
+			db: {
+				getAllMonitorsWithUptimeStats: sinon.stub(),
+			},
+		};
+		res = {
+			status: sinon.stub().returnsThis(),
+			json: sinon.stub(),
+		};
+		next = sinon.stub();
+	});
+	afterEach(() => {
+		sinon.restore();
+	});
+	it("should reject with an error if DB operations fail", async () => {
+		req.db.getAllMonitorsWithUptimeStats.throws(new Error("DB error"));
+		await getAllMonitorsWithUptimeStats(req, res, next);
+		expect(next.firstCall.args[0]).to.be.an("error");
+		expect(next.firstCall.args[0].message).to.equal("DB error");
+	});
+
+	it("should return success message and data if all operations succeed", async () => {
+		const data = [{ monitor: "data" }];
+		req.db.getAllMonitorsWithUptimeStats.returns(data);
+		await getAllMonitorsWithUptimeStats(req, res, next);
 		expect(res.status.firstCall.args[0]).to.equal(200);
 		expect(
 			res.json.calledOnceWith({

--- a/Server/tests/db/checkModule.test.js
+++ b/Server/tests/db/checkModule.test.js
@@ -1,0 +1,565 @@
+import sinon from "sinon";
+import {
+	createCheck,
+	getChecksCount,
+	getChecks,
+	getTeamChecks,
+	deleteChecks,
+	deleteChecksByTeamId,
+	updateChecksTTL,
+} from "../../db/mongo/modules/checkModule.js";
+import Check from "../../db/models/Check.js";
+import Monitor from "../../db/models/Monitor.js";
+import User from "../../db/models/User.js";
+import logger from "../../utils/logger.js";
+
+describe("checkModule", () => {
+	describe("createCheck", () => {
+		let checkCountDocumentsStub, checkSaveStub, monitorFindByIdStub, monitorSaveStub;
+		const mockMonitor = {
+			_id: "123",
+			uptimePercentage: 0.5,
+			status: true,
+			save: () => this,
+		};
+		const mockCheck = { active: true };
+		beforeEach(() => {
+			checkSaveStub = sinon.stub(Check.prototype, "save");
+			checkCountDocumentsStub = sinon.stub(Check, "countDocuments");
+			monitorFindByIdStub = sinon.stub(Monitor, "findById");
+			monitorSaveStub = sinon.stub(Monitor.prototype, "save");
+		});
+
+		afterEach(() => {
+			sinon.restore();
+		});
+
+		it("should return undefined early if no monitor is found", async () => {
+			monitorFindByIdStub.returns(null);
+			const check = await createCheck({ monitorId: "123" });
+			expect(check).to.be.undefined;
+		});
+
+		it("should return a check", async () => {
+			monitorFindByIdStub.returns(mockMonitor);
+			checkSaveStub.returns(mockCheck);
+			monitorSaveStub.returns(mockMonitor);
+			const check = await createCheck({ monitorId: "123", status: true });
+			expect(check).to.deep.equal(mockCheck);
+		});
+		it("should return a check if status is down", async () => {
+			mockMonitor.status = false;
+			monitorFindByIdStub.returns(mockMonitor);
+			checkSaveStub.returns(mockCheck);
+			monitorSaveStub.returns(mockMonitor);
+			const check = await createCheck({ monitorId: "123", status: false });
+			expect(check).to.deep.equal(mockCheck);
+		});
+		it("should return a check if uptimePercentage is undefined", async () => {
+			mockMonitor.uptimePercentage = undefined;
+			monitorFindByIdStub.returns(mockMonitor);
+			checkSaveStub.returns(mockCheck);
+			monitorSaveStub.returns(mockMonitor);
+			const check = await createCheck({ monitorId: "123", status: true });
+			expect(check).to.deep.equal(mockCheck);
+		});
+		it("should return a check if uptimePercentage is undefined and status is down", async () => {
+			mockMonitor.uptimePercentage = undefined;
+			monitorFindByIdStub.returns(mockMonitor);
+			checkSaveStub.returns(mockCheck);
+			monitorSaveStub.returns(mockMonitor);
+			const check = await createCheck({ monitorId: "123", status: false });
+			expect(check).to.deep.equal(mockCheck);
+		});
+		it("should monitor save error", async () => {
+			const err = new Error("Save Error");
+			monitorSaveStub.throws(err);
+			try {
+				await createCheck({ monitorId: "123" });
+			} catch (error) {
+				expect(error).to.deep.equal(err);
+			}
+		});
+		it("should handle errors", async () => {
+			const err = new Error("DB Error");
+			checkCountDocumentsStub.throws(err);
+			try {
+				await createCheck({ monitorId: "123" });
+			} catch (error) {
+				expect(error).to.deep.equal(err);
+			}
+		});
+	});
+	describe("getChecksCount", () => {
+		let checkCountDocumentStub;
+
+		beforeEach(() => {
+			checkCountDocumentStub = sinon.stub(Check, "countDocuments");
+		});
+
+		afterEach(() => {
+			checkCountDocumentStub.restore();
+		});
+
+		it("should return count with basic monitorId query", async () => {
+			const req = {
+				params: { monitorId: "test123" },
+				query: {},
+			};
+			checkCountDocumentStub.resolves(5);
+
+			const result = await getChecksCount(req);
+
+			expect(result).to.equal(5);
+			expect(checkCountDocumentStub.calledOnce).to.be.true;
+			expect(checkCountDocumentStub.firstCall.args[0]).to.deep.equal({
+				monitorId: "test123",
+			});
+		});
+
+		it("should include dateRange in query when provided", async () => {
+			const req = {
+				params: { monitorId: "test123" },
+				query: { dateRange: "day" },
+			};
+			checkCountDocumentStub.resolves(3);
+
+			const result = await getChecksCount(req);
+
+			expect(result).to.equal(3);
+			expect(checkCountDocumentStub.firstCall.args[0]).to.have.property("createdAt");
+			expect(checkCountDocumentStub.firstCall.args[0].createdAt).to.have.property("$gte");
+		});
+
+		it('should handle "all" filter correctly', async () => {
+			const req = {
+				params: { monitorId: "test123" },
+				query: { filter: "all" },
+			};
+			checkCountDocumentStub.resolves(2);
+
+			const result = await getChecksCount(req);
+
+			expect(result).to.equal(2);
+			expect(checkCountDocumentStub.firstCall.args[0]).to.deep.equal({
+				monitorId: "test123",
+				status: false,
+			});
+		});
+
+		it('should handle "down" filter correctly', async () => {
+			const req = {
+				params: { monitorId: "test123" },
+				query: { filter: "down" },
+			};
+			checkCountDocumentStub.resolves(2);
+
+			const result = await getChecksCount(req);
+
+			expect(result).to.equal(2);
+			expect(checkCountDocumentStub.firstCall.args[0]).to.deep.equal({
+				monitorId: "test123",
+				status: false,
+			});
+		});
+
+		it('should handle "resolve" filter correctly', async () => {
+			const req = {
+				params: { monitorId: "test123" },
+				query: { filter: "resolve" },
+			};
+			checkCountDocumentStub.resolves(1);
+
+			const result = await getChecksCount(req);
+
+			expect(result).to.equal(1);
+			expect(checkCountDocumentStub.firstCall.args[0]).to.deep.equal({
+				monitorId: "test123",
+				status: false,
+				statusCode: 5000,
+			});
+		});
+		it("should handle unknown filter correctly", async () => {
+			const req = {
+				params: { monitorId: "test123" },
+				query: { filter: "unknown" },
+			};
+			checkCountDocumentStub.resolves(1);
+
+			const result = await getChecksCount(req);
+
+			expect(result).to.equal(1);
+			expect(checkCountDocumentStub.firstCall.args[0]).to.deep.equal({
+				monitorId: "test123",
+				status: false,
+			});
+		});
+
+		it("should combine dateRange and filter in query", async () => {
+			const req = {
+				params: { monitorId: "test123" },
+				query: {
+					dateRange: "week",
+					filter: "down",
+				},
+			};
+			checkCountDocumentStub.resolves(4);
+
+			const result = await getChecksCount(req);
+
+			expect(result).to.equal(4);
+			expect(checkCountDocumentStub.firstCall.args[0]).to.have.all.keys(
+				"monitorId",
+				"createdAt",
+				"status"
+			);
+		});
+	});
+	describe("getChecks", () => {
+		let checkFindStub, monitorFindStub;
+
+		beforeEach(() => {
+			checkFindStub = sinon.stub(Check, "find").returns({
+				skip: sinon.stub().returns({
+					limit: sinon.stub().returns({
+						sort: sinon.stub().returns([{ id: 1 }, { id: 2 }]),
+					}),
+				}),
+			});
+		});
+
+		afterEach(() => {
+			sinon.restore();
+		});
+
+		it("should return checks with basic monitorId query", async () => {
+			const req = {
+				params: { monitorId: "test123" },
+				query: {},
+			};
+
+			const result = await getChecks(req);
+
+			expect(result).to.deep.equal([{ id: 1 }, { id: 2 }]);
+		});
+		it("should return checks with limit query", async () => {
+			const req = {
+				params: { monitorId: "test123" },
+				query: { limit: 10 },
+			};
+
+			const result = await getChecks(req);
+
+			expect(result).to.deep.equal([{ id: 1 }, { id: 2 }]);
+		});
+
+		it("should handle pagination correctly", async () => {
+			const req = {
+				params: { monitorId: "test123" },
+				query: {
+					page: 2,
+					rowsPerPage: 10,
+				},
+			};
+
+			const result = await getChecks(req);
+
+			expect(result).to.deep.equal([{ id: 1 }, { id: 2 }]);
+		});
+
+		it("should handle dateRange filter", async () => {
+			const req = {
+				params: { monitorId: "test123" },
+				query: { dateRange: "week" },
+			};
+			const result = await getChecks(req);
+
+			expect(result).to.deep.equal([{ id: 1 }, { id: 2 }]);
+		});
+
+		it('should handle "all" filter', async () => {
+			const req = {
+				params: { monitorId: "test123" },
+				query: { filter: "all" },
+			};
+
+			await getChecks(req);
+			const result = await getChecks(req);
+			expect(result).to.deep.equal([{ id: 1 }, { id: 2 }]);
+		});
+		it('should handle "down" filter', async () => {
+			const req = {
+				params: { monitorId: "test123" },
+				query: { filter: "down" },
+			};
+
+			await getChecks(req);
+			const result = await getChecks(req);
+			expect(result).to.deep.equal([{ id: 1 }, { id: 2 }]);
+		});
+
+		it('should handle "resolve" filter', async () => {
+			const req = {
+				params: { monitorId: "test123" },
+				query: { filter: "resolve" },
+			};
+
+			await getChecks(req);
+			const result = await getChecks(req);
+			expect(result).to.deep.equal([{ id: 1 }, { id: 2 }]);
+		});
+		it('should handle "unknown" filter', async () => {
+			const req = {
+				params: { monitorId: "test123" },
+				query: { filter: "unknown" },
+			};
+
+			await getChecks(req);
+			const result = await getChecks(req);
+			expect(result).to.deep.equal([{ id: 1 }, { id: 2 }]);
+		});
+
+		it("should handle ascending sort order", async () => {
+			const req = {
+				params: { monitorId: "test123" },
+				query: { sortOrder: "asc" },
+			};
+
+			await getChecks(req);
+			const result = await getChecks(req);
+			expect(result).to.deep.equal([{ id: 1 }, { id: 2 }]);
+		});
+
+		it("should handle error case", async () => {
+			const req = {
+				params: { monitorId: "test123" },
+				query: {},
+			};
+
+			checkFindStub.throws(new Error("Database error"));
+
+			try {
+				await getChecks(req);
+			} catch (error) {
+				expect(error.message).to.equal("Database error");
+				expect(error.service).to.equal("checkModule");
+				expect(error.method).to.equal("getChecks");
+			}
+		});
+	});
+	describe("getTeamChecks", () => {
+		let checkFindStub, checkCountDocumentsStub, monitorFindStub;
+		const mockMonitors = [{ _id: "123" }];
+		beforeEach(() => {
+			monitorFindStub = sinon.stub(Monitor, "find").returns({
+				select: sinon.stub().returns(mockMonitors),
+			});
+			checkCountDocumentsStub = sinon.stub(Check, "countDocuments").returns(2);
+			checkFindStub = sinon.stub(Check, "find").returns({
+				skip: sinon.stub().returns({
+					limit: sinon.stub().returns({
+						sort: sinon.stub().returns({
+							select: sinon.stub().returns([{ id: 1 }, { id: 2 }]),
+						}),
+					}),
+				}),
+			});
+		});
+
+		afterEach(() => {
+			sinon.restore();
+		});
+
+		it("should return checks with basic monitorId query", async () => {
+			const req = {
+				params: { teamId: "test123" },
+				query: {},
+			};
+
+			const result = await getTeamChecks(req);
+			expect(result).to.deep.equal({ checksCount: 2, checks: [{ id: 1 }, { id: 2 }] });
+		});
+
+		it("should handle pagination correctly", async () => {
+			const req = {
+				params: { monitorId: "test123" },
+				query: { limit: 1, page: 2, rowsPerPage: 10 },
+			};
+
+			const result = await getTeamChecks(req);
+			expect(result).to.deep.equal({ checksCount: 2, checks: [{ id: 1 }, { id: 2 }] });
+		});
+
+		it("should handle dateRange filter", async () => {
+			const req = {
+				params: { monitorId: "test123" },
+				query: { dateRange: "week" },
+			};
+			const result = await getTeamChecks(req);
+			expect(result).to.deep.equal({ checksCount: 2, checks: [{ id: 1 }, { id: 2 }] });
+		});
+
+		it('should handle "all" filter', async () => {
+			const req = {
+				params: { monitorId: "test123" },
+				query: { filter: "all" },
+			};
+
+			await getChecks(req);
+			const result = await getTeamChecks(req);
+			expect(result).to.deep.equal({ checksCount: 2, checks: [{ id: 1 }, { id: 2 }] });
+		});
+		it('should handle "down" filter', async () => {
+			const req = {
+				params: { monitorId: "test123" },
+				query: { filter: "down" },
+			};
+
+			await getChecks(req);
+			const result = await getTeamChecks(req);
+			expect(result).to.deep.equal({ checksCount: 2, checks: [{ id: 1 }, { id: 2 }] });
+		});
+
+		it('should handle "resolve" filter', async () => {
+			const req = {
+				params: { monitorId: "test123" },
+				query: { filter: "resolve" },
+			};
+
+			await getChecks(req);
+			const result = await getTeamChecks(req);
+			expect(result).to.deep.equal({ checksCount: 2, checks: [{ id: 1 }, { id: 2 }] });
+		});
+		it('should handle "unknown" filter', async () => {
+			const req = {
+				params: { monitorId: "test123" },
+				query: { filter: "unknown" },
+			};
+
+			await getChecks(req);
+			const result = await getTeamChecks(req);
+			expect(result).to.deep.equal({ checksCount: 2, checks: [{ id: 1 }, { id: 2 }] });
+		});
+
+		it("should handle ascending sort order", async () => {
+			const req = {
+				params: { monitorId: "test123" },
+				query: { sortOrder: "asc" },
+			};
+
+			await getChecks(req);
+			const result = await getTeamChecks(req);
+			expect(result).to.deep.equal({ checksCount: 2, checks: [{ id: 1 }, { id: 2 }] });
+		});
+
+		it("should handle error case", async () => {
+			const req = {
+				params: { monitorId: "test123" },
+				query: {},
+			};
+
+			checkFindStub.throws(new Error("Database error"));
+
+			try {
+				await getTeamChecks(req);
+			} catch (error) {
+				expect(error.message).to.equal("Database error");
+				expect(error.service).to.equal("checkModule");
+				expect(error.method).to.equal("getTeamChecks");
+			}
+		});
+	});
+	describe("deleteChecks", () => {
+		let checkDeleteManyStub;
+		beforeEach(() => {
+			checkDeleteManyStub = sinon.stub(Check, "deleteMany").resolves({ deletedCount: 1 });
+		});
+		afterEach(() => {
+			sinon.restore();
+		});
+
+		it("should return a value if a check is deleted", async () => {
+			const result = await deleteChecks("123");
+			expect(result).to.equal(1);
+		});
+		it("should handle an error", async () => {
+			checkDeleteManyStub.throws(new Error("Database error"));
+			try {
+				await deleteChecks("123");
+			} catch (error) {
+				expect(error.message).to.equal("Database error");
+				expect(error.method).to.equal("deleteChecks");
+			}
+		});
+	});
+	describe("deleteChecksByTeamId", () => {
+		let mockMonitors = [{ _id: 123, save: () => this }];
+		let monitorFindStub, monitorSaveStub, checkDeleteManyStub;
+		beforeEach(() => {
+			monitorSaveStub = sinon.stub(Monitor.prototype, "save");
+			monitorFindStub = sinon.stub(Monitor, "find").returns(mockMonitors);
+			checkDeleteManyStub = sinon.stub(Check, "deleteMany").resolves({ deletedCount: 1 });
+		});
+		afterEach(() => {
+			sinon.restore();
+		});
+		it("should return a deleted count", async () => {
+			const result = await deleteChecksByTeamId("123");
+			expect(result).to.equal(1);
+		});
+		it("should handle errors", async () => {
+			const err = new Error("DB Error");
+			monitorFindStub.throws(err);
+			try {
+				const result = await deleteChecksByTeamId("123");
+			} catch (error) {
+				expect(error).to.deep.equal(err);
+			}
+		});
+	});
+	describe("updateChecksTTL", () => {
+		let userUpdateManyStub;
+		let loggerStub;
+		beforeEach(() => {
+			loggerStub = sinon.stub(logger, "error");
+			userUpdateManyStub = sinon.stub(User, "updateMany");
+			Check.collection = { dropIndex: sinon.stub(), createIndex: sinon.stub() };
+		});
+
+		afterEach(() => {
+			sinon.restore();
+		});
+
+		it("should return undefined", async () => {
+			const result = await updateChecksTTL("123", 10);
+			expect(result).to.be.undefined;
+		});
+
+		it("should log an error if dropIndex throws an error", async () => {
+			const err = new Error("Drop Index Error");
+			Check.collection.dropIndex.throws(err);
+			await updateChecksTTL("123", 10);
+			expect(loggerStub.calledOnce).to.be.true;
+			expect(loggerStub.firstCall.args[0].message).to.equal(err.message);
+		});
+
+		it("should throw an error if createIndex throws an error", async () => {
+			const err = new Error("Create Index Error");
+			Check.collection.createIndex.throws(err);
+			try {
+				await updateChecksTTL("123", 10);
+			} catch (error) {
+				expect(error).to.deep.equal(err);
+			}
+		});
+		it("should throw an error if User.updateMany throws an error", async () => {
+			const err = new Error("Update Many Error");
+			userUpdateManyStub.throws(err);
+			try {
+				await updateChecksTTL("123", 10);
+			} catch (error) {
+				expect(error).to.deep.equal(err);
+			}
+		});
+	});
+});

--- a/Server/tests/db/monitorModule.test.js
+++ b/Server/tests/db/monitorModule.test.js
@@ -1,0 +1,1581 @@
+import sinon from "sinon";
+import Monitor from "../../db/models/Monitor.js";
+import Check from "../../db/models/Check.js";
+import Notification from "../../db/models/Notification.js";
+
+import { errorMessages } from "../../utils/messages.js";
+import {
+	getAllMonitors,
+	getMonitorStatsById,
+	getMonitorById,
+	getMonitorsAndSummaryByTeamId,
+	getMonitorsByTeamId,
+	createMonitor,
+	deleteMonitor,
+	deleteAllMonitors,
+	deleteMonitorsByUserId,
+	editMonitor,
+	addDemoMonitors,
+	calculateUptimeDuration,
+	getLastChecked,
+	getLatestResponseTime,
+	getAverageResponseTime,
+	getUptimePercentage,
+	getIncidents,
+	getDateRange,
+	getMonitorChecks,
+	processChecksForDisplay,
+	groupChecksByTime,
+	calculateGroupStats,
+} from "../../db/mongo/modules/monitorModule.js";
+
+describe("monitorModule", () => {
+	let monitorFindStub,
+		monitorFindByIdStub,
+		monitorFindByIdAndUpdateStub,
+		monitorFindByIdAndDeleteStub,
+		monitorDeleteManyStub,
+		monitorCountStub,
+		monitorInsertManyStub,
+		checkFindStub;
+	beforeEach(() => {
+		monitorFindStub = sinon.stub(Monitor, "find");
+		monitorFindByIdStub = sinon.stub(Monitor, "findById");
+		monitorFindByIdAndUpdateStub = sinon.stub(Monitor, "findByIdAndUpdate");
+		monitorFindByIdAndDeleteStub = sinon.stub(Monitor, "findByIdAndDelete");
+		monitorDeleteManyStub = sinon.stub(Monitor, "deleteMany");
+		monitorCountStub = sinon.stub(Monitor, "countDocuments");
+
+		monitorInsertManyStub = sinon.stub(Monitor, "insertMany");
+		checkFindStub = sinon.stub(Check, "find").returns({
+			sort: sinon.stub(),
+		});
+	});
+	afterEach(() => {
+		sinon.restore();
+	});
+
+	describe("getAllMonitors", () => {
+		it("should return all monitors", async () => {
+			const mockMonitors = [
+				{ _id: "1", name: "Monitor 1", url: "test1.com" },
+				{ _id: "2", name: "Monitor 2", url: "test2.com" },
+			];
+			monitorFindStub.returns(mockMonitors);
+			const result = await getAllMonitors();
+
+			expect(result).to.deep.equal(mockMonitors);
+			expect(monitorFindStub.calledOnce).to.be.true;
+			expect(monitorFindStub.firstCall.args).to.deep.equal([]);
+		});
+		it("should handle empty results", async () => {
+			monitorFindStub.returns([]);
+			const result = await getAllMonitors();
+			expect(result).to.be.an("array").that.is.empty;
+		});
+		it("should throw error when database fails", async () => {
+			// Arrange
+			const error = new Error("Database error");
+			error.service = "MonitorModule";
+			error.method = "getAllMonitors";
+			monitorFindStub.rejects(error);
+			// Act & Assert
+			try {
+				await getAllMonitors();
+				expect.fail("Should have thrown an error");
+			} catch (err) {
+				expect(err).to.equal(error);
+				expect(err.service).to.equal("monitorModule");
+				expect(err.method).to.equal("getAllMonitors");
+			}
+		});
+	});
+
+	describe("calculateUptimeDuration", () => {
+		let clock;
+		const NOW = new Date("2024-01-01T12:00:00Z").getTime();
+
+		beforeEach(() => {
+			// Fix the current time
+			clock = sinon.useFakeTimers(NOW);
+		});
+
+		afterEach(() => {
+			clock.restore();
+		});
+
+		it("should return 0 when checks array is empty", () => {
+			expect(calculateUptimeDuration([])).to.equal(0);
+		});
+
+		it("should return 0 when checks array is null", () => {
+			expect(calculateUptimeDuration(null)).to.equal(0);
+		});
+
+		it("should calculate uptime from last down check to most recent check", () => {
+			const checks = [
+				{ status: true, createdAt: "2024-01-01T11:00:00Z" }, // Most recent
+				{ status: true, createdAt: "2024-01-01T10:00:00Z" },
+				{ status: false, createdAt: "2024-01-01T09:00:00Z" }, // Last down
+				{ status: true, createdAt: "2024-01-01T08:00:00Z" },
+			];
+
+			// Expected: 2 hours (from 09:00 to 11:00) = 7200000ms
+			expect(calculateUptimeDuration(checks)).to.equal(7200000);
+		});
+
+		it("should calculate uptime from first check when no down checks exist", () => {
+			const checks = [
+				{ status: true, createdAt: "2024-01-01T11:00:00Z" },
+				{ status: true, createdAt: "2024-01-01T10:00:00Z" },
+				{ status: true, createdAt: "2024-01-01T09:00:00Z" },
+			];
+
+			// Expected: Current time (12:00) - First check (09:00) = 3 hours = 10800000ms
+			expect(calculateUptimeDuration(checks)).to.equal(10800000);
+		});
+	});
+
+	describe("getLastChecked", () => {
+		let clock;
+		const NOW = new Date("2024-01-01T12:00:00Z").getTime();
+
+		beforeEach(() => {
+			// Fix the current time
+			clock = sinon.useFakeTimers(NOW);
+		});
+
+		afterEach(() => {
+			clock.restore();
+		});
+
+		it("should return 0 when checks array is empty", () => {
+			expect(getLastChecked([])).to.equal(0);
+		});
+
+		it("should return 0 when checks array is null", () => {
+			expect(getLastChecked(null)).to.equal(0);
+		});
+
+		it("should return time difference between now and most recent check", () => {
+			const checks = [
+				{ createdAt: "2024-01-01T11:30:00Z" }, // 30 minutes ago
+				{ createdAt: "2024-01-01T11:00:00Z" },
+				{ createdAt: "2024-01-01T10:30:00Z" },
+			];
+
+			// Expected: 30 minutes = 1800000ms
+			expect(getLastChecked(checks)).to.equal(1800000);
+		});
+
+		it("should handle checks from different days", () => {
+			const checks = [
+				{ createdAt: "2023-12-31T12:00:00Z" }, // 24 hours ago
+				{ createdAt: "2023-12-30T12:00:00Z" },
+			];
+
+			// Expected: 24 hours = 86400000ms
+			expect(getLastChecked(checks)).to.equal(86400000);
+		});
+	});
+	describe("getLatestResponseTime", () => {
+		it("should return 0 when checks array is empty", () => {
+			expect(getLatestResponseTime([])).to.equal(0);
+		});
+
+		it("should return 0 when checks array is null", () => {
+			expect(getLatestResponseTime(null)).to.equal(0);
+		});
+
+		it("should return response time from most recent check", () => {
+			const checks = [
+				{ responseTime: 150, createdAt: "2024-01-01T11:30:00Z" }, // Most recent
+				{ responseTime: 200, createdAt: "2024-01-01T11:00:00Z" },
+				{ responseTime: 250, createdAt: "2024-01-01T10:30:00Z" },
+			];
+
+			expect(getLatestResponseTime(checks)).to.equal(150);
+		});
+
+		it("should handle missing responseTime in checks", () => {
+			const checks = [
+				{ createdAt: "2024-01-01T11:30:00Z" },
+				{ responseTime: 200, createdAt: "2024-01-01T11:00:00Z" },
+			];
+
+			expect(getLatestResponseTime(checks)).to.equal(0);
+		});
+	});
+	describe("getAverageResponseTime", () => {
+		it("should return 0 when checks array is empty", () => {
+			expect(getAverageResponseTime([])).to.equal(0);
+		});
+
+		it("should return 0 when checks array is null", () => {
+			expect(getAverageResponseTime(null)).to.equal(0);
+		});
+
+		it("should calculate average response time from all checks", () => {
+			const checks = [
+				{ responseTime: 100, createdAt: "2024-01-01T11:30:00Z" },
+				{ responseTime: 200, createdAt: "2024-01-01T11:00:00Z" },
+				{ responseTime: 300, createdAt: "2024-01-01T10:30:00Z" },
+			];
+
+			// Average: (100 + 200 + 300) / 3 = 200
+			expect(getAverageResponseTime(checks)).to.equal(200);
+		});
+
+		it("should handle missing responseTime in some checks", () => {
+			const checks = [
+				{ responseTime: 100, createdAt: "2024-01-01T11:30:00Z" },
+				{ createdAt: "2024-01-01T11:00:00Z" },
+				{ responseTime: 300, createdAt: "2024-01-01T10:30:00Z" },
+			];
+
+			// Average: (100 + 300) / 2 = 200
+			expect(getAverageResponseTime(checks)).to.equal(200);
+		});
+
+		it("should return 0 when no checks have responseTime", () => {
+			const checks = [
+				{ createdAt: "2024-01-01T11:30:00Z" },
+				{ createdAt: "2024-01-01T11:00:00Z" },
+			];
+
+			expect(getAverageResponseTime(checks)).to.equal(0);
+		});
+	});
+	describe("getUptimePercentage", () => {
+		it("should return 0 when checks array is empty", () => {
+			expect(getUptimePercentage([])).to.equal(0);
+		});
+
+		it("should return 0 when checks array is null", () => {
+			expect(getUptimePercentage(null)).to.equal(0);
+		});
+
+		it("should return 100 when all checks are up", () => {
+			const checks = [{ status: true }, { status: true }, { status: true }];
+			expect(getUptimePercentage(checks)).to.equal(100);
+		});
+
+		it("should return 0 when all checks are down", () => {
+			const checks = [{ status: false }, { status: false }, { status: false }];
+			expect(getUptimePercentage(checks)).to.equal(0);
+		});
+
+		it("should calculate correct percentage for mixed status checks", () => {
+			const checks = [
+				{ status: true },
+				{ status: false },
+				{ status: true },
+				{ status: true },
+			];
+			// 3 up out of 4 total = 75%
+			expect(getUptimePercentage(checks)).to.equal(75);
+		});
+
+		it("should handle undefined status values", () => {
+			const checks = [{ status: true }, { status: undefined }, { status: true }];
+			// 2 up out of 3 total ≈ 66.67%
+			expect(getUptimePercentage(checks)).to.equal((2 / 3) * 100);
+		});
+	});
+	describe("getIncidents", () => {
+		it("should return 0 when checks array is empty", () => {
+			expect(getIncidents([])).to.equal(0);
+		});
+
+		it("should return 0 when checks array is null", () => {
+			expect(getIncidents(null)).to.equal(0);
+		});
+
+		it("should return 0 when all checks are up", () => {
+			const checks = [{ status: true }, { status: true }, { status: true }];
+			expect(getIncidents(checks)).to.equal(0);
+		});
+
+		it("should count all incidents when all checks are down", () => {
+			const checks = [{ status: false }, { status: false }, { status: false }];
+			expect(getIncidents(checks)).to.equal(3);
+		});
+
+		it("should count correct number of incidents for mixed status checks", () => {
+			const checks = [
+				{ status: true },
+				{ status: false },
+				{ status: true },
+				{ status: false },
+				{ status: true },
+			];
+			expect(getIncidents(checks)).to.equal(2);
+		});
+
+		it("should handle undefined status values", () => {
+			const checks = [
+				{ status: true },
+				{ status: undefined },
+				{ status: false },
+				{ status: false },
+			];
+			// Only counts explicit false values
+			expect(getIncidents(checks)).to.equal(2);
+		});
+	});
+	describe("getMonitorChecks", () => {
+		let mockModel;
+
+		beforeEach(() => {
+			// Create a mock model with chainable methods
+			const mockChecks = [
+				{ monitorId: "123", createdAt: new Date("2024-01-01") },
+				{ monitorId: "123", createdAt: new Date("2024-01-02") },
+			];
+
+			mockModel = {
+				find: sinon.stub().returns({
+					sort: sinon.stub().returns(mockChecks),
+				}),
+			};
+		});
+
+		afterEach(() => {
+			sinon.restore();
+		});
+
+		it("should return all checks and date-ranged checks", async () => {
+			// Arrange
+			const monitorId = "123";
+			const dateRange = {
+				start: new Date("2024-01-01"),
+				end: new Date("2024-01-02"),
+			};
+			const sortOrder = -1;
+
+			// Act
+			const result = await getMonitorChecks(monitorId, mockModel, dateRange, sortOrder);
+
+			// Assert
+			expect(result).to.have.keys(["checksAll", "checksForDateRange"]);
+
+			// Verify find was called with correct parameters
+			expect(mockModel.find.firstCall.args[0]).to.deep.equal({ monitorId });
+			expect(mockModel.find.secondCall.args[0]).to.deep.equal({
+				monitorId,
+				createdAt: { $gte: dateRange.start, $lte: dateRange.end },
+			});
+
+			// Verify sort was called with correct parameters
+			const sortCalls = mockModel.find().sort.getCalls();
+			sortCalls.forEach((call) => {
+				expect(call.args[0]).to.deep.equal({ createdAt: sortOrder });
+			});
+		});
+
+		it("should handle empty results", async () => {
+			// Arrange
+			const emptyModel = {
+				find: sinon.stub().returns({
+					sort: sinon.stub().returns([]),
+				}),
+			};
+
+			// Act
+			const result = await getMonitorChecks(
+				"123",
+				emptyModel,
+				{
+					start: new Date(),
+					end: new Date(),
+				},
+				-1
+			);
+
+			// Assert
+			expect(result.checksAll).to.be.an("array").that.is.empty;
+			expect(result.checksForDateRange).to.be.an("array").that.is.empty;
+		});
+
+		it("should maintain sort order", async () => {
+			// Arrange
+			const sortedChecks = [
+				{ monitorId: "123", createdAt: new Date("2024-01-02") },
+				{ monitorId: "123", createdAt: new Date("2024-01-01") },
+			];
+
+			const sortedModel = {
+				find: sinon.stub().returns({
+					sort: sinon.stub().returns(sortedChecks),
+				}),
+			};
+
+			// Act
+			const result = await getMonitorChecks(
+				"123",
+				sortedModel,
+				{
+					start: new Date("2024-01-01"),
+					end: new Date("2024-01-02"),
+				},
+				-1
+			);
+
+			// Assert
+			expect(result.checksAll[0].createdAt).to.be.greaterThan(
+				result.checksAll[1].createdAt
+			);
+			expect(result.checksForDateRange[0].createdAt).to.be.greaterThan(
+				result.checksForDateRange[1].createdAt
+			);
+		});
+	});
+
+	describe("processChecksForDisplay", () => {
+		let normalizeStub;
+
+		beforeEach(() => {
+			normalizeStub = sinon.stub();
+		});
+
+		it("should return original checks when numToDisplay is not provided", () => {
+			const checks = [1, 2, 3, 4, 5];
+			const result = processChecksForDisplay(normalizeStub, checks);
+			expect(result).to.deep.equal(checks);
+		});
+
+		it("should return original checks when numToDisplay is greater than checks length", () => {
+			const checks = [1, 2, 3];
+			const result = processChecksForDisplay(normalizeStub, checks, 5);
+			expect(result).to.deep.equal(checks);
+		});
+
+		it("should filter checks based on numToDisplay", () => {
+			const checks = [1, 2, 3, 4, 5, 6];
+			const result = processChecksForDisplay(normalizeStub, checks, 3);
+			// Should return [1, 3, 5] as n = ceil(6/3) = 2
+			expect(result).to.deep.equal([1, 3, 5]);
+		});
+
+		it("should handle empty checks array", () => {
+			const checks = [];
+			const result = processChecksForDisplay(normalizeStub, checks, 3);
+			expect(result).to.be.an("array").that.is.empty;
+		});
+
+		it("should call normalizeData when normalize is true", () => {
+			const checks = [1, 2, 3];
+			normalizeStub.returns([10, 20, 30]);
+
+			const result = processChecksForDisplay(normalizeStub, checks, null, true);
+
+			expect(normalizeStub.args[0]).to.deep.equal([checks, 1, 100]);
+			expect(result).to.deep.equal([10, 20, 30]);
+		});
+
+		it("should handle both filtering and normalization", () => {
+			const checks = [1, 2, 3, 4, 5, 6];
+			normalizeStub.returns([10, 30, 50]);
+
+			const result = processChecksForDisplay(normalizeStub, checks, 3, true);
+
+			expect(normalizeStub.args[0][0]).to.deep.equal([1, 3, 5]);
+			expect(result).to.deep.equal([10, 30, 50]);
+		});
+	});
+	describe("groupChecksByTime", () => {
+		const mockChecks = [
+			{ createdAt: "2024-01-15T10:30:45Z" },
+			{ createdAt: "2024-01-15T10:45:15Z" },
+			{ createdAt: "2024-01-15T11:15:00Z" },
+			{ createdAt: "2024-01-16T10:30:00Z" },
+		];
+
+		it("should group checks by hour when dateRange is 'day'", () => {
+			const result = groupChecksByTime(mockChecks, "day");
+
+			// Get timestamps for 10:00 and 11:00 on Jan 15
+			const time1 = new Date("2024-01-15T10:00:00Z").getTime();
+			const time2 = new Date("2024-01-15T11:00:00Z").getTime();
+			const time3 = new Date("2024-01-16T10:00:00Z").getTime();
+
+			expect(Object.keys(result)).to.have.lengthOf(3);
+
+			expect(result[time1].checks).to.have.lengthOf(2);
+			expect(result[time2].checks).to.have.lengthOf(1);
+			expect(result[time3].checks).to.have.lengthOf(1);
+		});
+
+		it("should group checks by day when dateRange is not 'day'", () => {
+			const result = groupChecksByTime(mockChecks, "week");
+
+			expect(Object.keys(result)).to.have.lengthOf(2);
+			expect(result["2024-01-15"].checks).to.have.lengthOf(3);
+			expect(result["2024-01-16"].checks).to.have.lengthOf(1);
+		});
+
+		it("should handle empty checks array", () => {
+			const result = groupChecksByTime([], "day");
+			expect(result).to.deep.equal({});
+		});
+
+		it("should handle single check", () => {
+			const singleCheck = [{ createdAt: "2024-01-15T10:30:45Z" }];
+			const result = groupChecksByTime(singleCheck, "day");
+
+			const expectedTime = new Date("2024-01-15T10:00:00Z").getTime();
+			expect(Object.keys(result)).to.have.lengthOf(1);
+			expect(result[expectedTime].checks).to.have.lengthOf(1);
+		});
+		it("should skip invalid dates and process valid ones", () => {
+			const checksWithInvalidDate = [
+				{ createdAt: "invalid-date" },
+				{ createdAt: "2024-01-15T10:30:45Z" },
+				{ createdAt: null },
+				{ createdAt: undefined },
+				{ createdAt: "" },
+			];
+
+			const result = groupChecksByTime(checksWithInvalidDate, "day");
+
+			const expectedTime = new Date("2024-01-15T10:00:00Z").getTime();
+			expect(Object.keys(result)).to.have.lengthOf(1);
+			expect(result[expectedTime].checks).to.have.lengthOf(1);
+			expect(result[expectedTime].checks[0].createdAt).to.equal("2024-01-15T10:30:45Z");
+		});
+		it("should handle checks in same time group", () => {
+			const checksInSameHour = [
+				{ createdAt: "2024-01-15T10:15:00Z" },
+				{ createdAt: "2024-01-15T10:45:00Z" },
+			];
+
+			const result = groupChecksByTime(checksInSameHour, "day");
+
+			const expectedTime = new Date("2024-01-15T10:00:00Z").getTime();
+			expect(Object.keys(result)).to.have.lengthOf(1);
+			expect(result[expectedTime].checks).to.have.lengthOf(2);
+		});
+	});
+	describe("calculateGroupStats", () => {
+		// Mock getUptimePercentage function
+		let uptimePercentageStub;
+
+		beforeEach(() => {
+			uptimePercentageStub = sinon.stub();
+			uptimePercentageStub.returns(95); // Default return value
+		});
+
+		it("should calculate stats correctly for a group of checks", () => {
+			const mockGroup = {
+				time: "2024-01-15",
+				checks: [
+					{ status: true, responseTime: 100 },
+					{ status: false, responseTime: 200 },
+					{ status: true, responseTime: 300 },
+				],
+			};
+
+			const result = calculateGroupStats(mockGroup, uptimePercentageStub);
+
+			expect(result).to.deep.equal({
+				time: "2024-01-15",
+				uptimePercentage: (2 / 3) * 100,
+				totalChecks: 3,
+				totalIncidents: 1,
+				avgResponseTime: 200, // (100 + 200 + 300) / 3
+			});
+		});
+
+		it("should handle empty checks array", () => {
+			const mockGroup = {
+				time: "2024-01-15",
+				checks: [],
+			};
+
+			const result = calculateGroupStats(mockGroup, uptimePercentageStub);
+
+			expect(result).to.deep.equal({
+				time: "2024-01-15",
+				uptimePercentage: 0,
+				totalChecks: 0,
+				totalIncidents: 0,
+				avgResponseTime: 0,
+			});
+		});
+
+		it("should handle missing responseTime values", () => {
+			const mockGroup = {
+				time: "2024-01-15",
+				checks: [
+					{ status: true },
+					{ status: false, responseTime: 200 },
+					{ status: true, responseTime: undefined },
+				],
+			};
+
+			const result = calculateGroupStats(mockGroup, uptimePercentageStub);
+
+			expect(result).to.deep.equal({
+				time: "2024-01-15",
+				uptimePercentage: (2 / 3) * 100,
+				totalChecks: 3,
+				totalIncidents: 1,
+				avgResponseTime: 200, // 200 / 1
+			});
+		});
+
+		it("should handle all checks with status false", () => {
+			const mockGroup = {
+				time: "2024-01-15",
+				checks: [
+					{ status: false, responseTime: 100 },
+					{ status: false, responseTime: 200 },
+					{ status: false, responseTime: 300 },
+				],
+			};
+
+			const result = calculateGroupStats(mockGroup, uptimePercentageStub);
+
+			expect(result).to.deep.equal({
+				time: "2024-01-15",
+				uptimePercentage: 0,
+				totalChecks: 3,
+				totalIncidents: 3,
+				avgResponseTime: 200,
+			});
+		});
+
+		it("should handle all checks with status true", () => {
+			const mockGroup = {
+				time: "2024-01-15",
+				checks: [
+					{ status: true, responseTime: 100 },
+					{ status: true, responseTime: 200 },
+					{ status: true, responseTime: 300 },
+				],
+			};
+
+			const result = calculateGroupStats(mockGroup, uptimePercentageStub);
+
+			expect(result).to.deep.equal({
+				time: "2024-01-15",
+				uptimePercentage: 100,
+				totalChecks: 3,
+				totalIncidents: 0,
+				avgResponseTime: 200,
+			});
+		});
+	});
+
+	describe("getMonitorStatsById", () => {
+		const now = new Date();
+		const oneHourAgo = new Date(now - 3600000);
+		const twoHoursAgo = new Date(now - 7200000);
+
+		const mockMonitor = {
+			_id: "monitor123",
+			type: "http",
+			name: "Test Monitor",
+			url: "https://test.com",
+			toObject: () => ({
+				_id: "monitor123",
+				type: "http",
+				name: "Test Monitor",
+				url: "https://test.com",
+			}),
+		};
+
+		const checkDocs = [
+			{
+				monitorId: "monitor123",
+				status: true,
+				responseTime: 100,
+				createdAt: new Date("2024-01-01T12:00:00Z"),
+				toObject: function () {
+					return {
+						monitorId: this.monitorId,
+						status: this.status,
+						responseTime: this.responseTime,
+						createdAt: this.createdAt,
+					};
+				},
+			},
+			{
+				monitorId: "monitor123",
+				status: true,
+				responseTime: 150,
+				createdAt: new Date("2024-01-01T11:00:00Z"),
+				toObject: function () {
+					return {
+						monitorId: this.monitorId,
+						status: this.status,
+						responseTime: this.responseTime,
+						createdAt: this.createdAt,
+					};
+				},
+			},
+			{
+				monitorId: "monitor123",
+				status: false,
+				responseTime: 200,
+				createdAt: new Date("2024-01-01T10:00:00Z"),
+				toObject: function () {
+					return {
+						monitorId: this.monitorId,
+						status: this.status,
+						responseTime: this.responseTime,
+						createdAt: this.createdAt,
+					};
+				},
+			},
+		];
+		const req = {
+			params: { monitorId: "monitor123" },
+			query: {
+				dateRange: "day",
+				sortOrder: "desc",
+				numToDisplay: 10,
+				normalize: true,
+			},
+		};
+
+		beforeEach(() => {
+			checkFindStub.returns({
+				sort: () => checkDocs,
+			});
+			monitorFindByIdStub.returns(mockMonitor);
+		});
+
+		afterEach(() => {
+			sinon.restore();
+		});
+
+		it("should return monitor stats with calculated values", async () => {
+			const result = await getMonitorStatsById(req);
+			expect(result).to.include.keys([
+				"_id",
+				"type",
+				"name",
+				"url",
+				"uptimeDuration",
+				"lastChecked",
+				"latestResponseTime",
+				"periodIncidents",
+				"periodTotalChecks",
+				"periodAvgResponseTime",
+				"periodUptime",
+				"aggregateData",
+			]);
+			expect(result.latestResponseTime).to.equal(100);
+			expect(result.periodTotalChecks).to.equal(3);
+			expect(result.periodIncidents).to.equal(1);
+			expect(result.periodUptime).to.be.a("number");
+			expect(result.aggregateData).to.be.an("array");
+		});
+		it("should throw error when monitor is not found", async () => {
+			monitorFindByIdStub.returns(Promise.resolve(null));
+
+			const req = {
+				params: { monitorId: "nonexistent" },
+				query: {},
+			};
+
+			try {
+				await getMonitorStatsById(req);
+				expect.fail("Should have thrown an error");
+			} catch (error) {
+				expect(error).to.be.an("Error");
+				expect(error.service).to.equal("monitorModule");
+				expect(error.method).to.equal("getMonitorStatsById");
+			}
+		});
+	});
+
+	describe("getMonitorById", () => {
+		let notificationFindStub;
+		let monitorSaveStub;
+
+		beforeEach(() => {
+			// Create stubs
+			notificationFindStub = sinon.stub(Notification, "find");
+			monitorSaveStub = sinon.stub().resolves();
+		});
+
+		afterEach(() => {
+			sinon.restore();
+		});
+
+		it("should return monitor with notifications when found", async () => {
+			// Arrange
+			const monitorId = "123";
+			const mockMonitor = {
+				_id: monitorId,
+				name: "Test Monitor",
+				save: monitorSaveStub,
+			};
+			const mockNotifications = [
+				{ _id: "notif1", message: "Test notification 1" },
+				{ _id: "notif2", message: "Test notification 2" },
+			];
+
+			monitorFindByIdStub.resolves(mockMonitor);
+			notificationFindStub.resolves(mockNotifications);
+
+			const result = await getMonitorById(monitorId);
+			expect(result._id).to.equal(monitorId);
+			expect(result.name).to.equal("Test Monitor");
+			expect(monitorFindByIdStub.calledWith(monitorId)).to.be.true;
+			expect(notificationFindStub.calledWith({ monitorId })).to.be.true;
+			expect(monitorSaveStub.calledOnce).to.be.true;
+		});
+
+		it("should throw 404 error when monitor not found", async () => {
+			// Arrange
+			const monitorId = "nonexistent";
+			monitorFindByIdStub.resolves(null);
+
+			// Act & Assert
+			try {
+				await getMonitorById(monitorId);
+				expect.fail("Should have thrown an error");
+			} catch (error) {
+				expect(error.message).to.equal(errorMessages.DB_FIND_MONITOR_BY_ID(monitorId));
+				expect(error.status).to.equal(404);
+				expect(error.service).to.equal("monitorModule");
+				expect(error.method).to.equal("getMonitorById");
+			}
+		});
+
+		it("should handle database errors properly", async () => {
+			// Arrange
+			const monitorId = "123";
+			const dbError = new Error("Database connection failed");
+			monitorFindByIdStub.rejects(dbError);
+
+			// Act & Assert
+			try {
+				await getMonitorById(monitorId);
+				expect.fail("Should have thrown an error");
+			} catch (error) {
+				expect(error.service).to.equal("monitorModule");
+				expect(error.method).to.equal("getMonitorById");
+				expect(error.message).to.equal("Database connection failed");
+			}
+		});
+
+		it("should handle notification fetch errors", async () => {
+			// Arrange
+			const monitorId = "123";
+			const mockMonitor = {
+				_id: monitorId,
+				name: "Test Monitor",
+				save: monitorSaveStub,
+			};
+			const notificationError = new Error("Notification fetch failed");
+
+			monitorFindByIdStub.resolves(mockMonitor);
+			notificationFindStub.rejects(notificationError);
+
+			// Act & Assert
+			try {
+				await getMonitorById(monitorId);
+				expect.fail("Should have thrown an error");
+			} catch (error) {
+				expect(error.service).to.equal("monitorModule");
+				expect(error.method).to.equal("getMonitorById");
+				expect(error.message).to.equal("Notification fetch failed");
+			}
+		});
+
+		it("should handle monitor save errors", async () => {
+			// Arrange
+			const monitorId = "123";
+			const mockMonitor = {
+				_id: monitorId,
+				name: "Test Monitor",
+				save: sinon.stub().rejects(new Error("Save failed")),
+			};
+			const mockNotifications = [];
+
+			monitorFindByIdStub.resolves(mockMonitor);
+			notificationFindStub.resolves(mockNotifications);
+
+			// Act & Assert
+			try {
+				await getMonitorById(monitorId);
+				expect.fail("Should have thrown an error");
+			} catch (error) {
+				expect(error.service).to.equal("monitorModule");
+				expect(error.method).to.equal("getMonitorById");
+				expect(error.message).to.equal("Save failed");
+			}
+		});
+	});
+	describe("getMonitorsAndSummaryByTeamId", () => {
+		it("should return monitors and correct summary counts", async () => {
+			// Arrange
+			const teamId = "team123";
+			const type = "http";
+			const mockMonitors = [
+				{ teamId, type, status: true, isActive: true }, // up
+				{ teamId, type, status: false, isActive: true }, // down
+				{ teamId, type, status: null, isActive: false }, // paused
+				{ teamId, type, status: true, isActive: true }, // up
+			];
+			monitorFindStub.resolves(mockMonitors);
+
+			// Act
+			const result = await getMonitorsAndSummaryByTeamId(teamId, type);
+
+			// Assert
+			expect(result.monitors).to.have.lengthOf(4);
+			expect(result.monitorCounts).to.deep.equal({
+				up: 2,
+				down: 1,
+				paused: 1,
+				total: 4,
+			});
+			expect(monitorFindStub.calledOnceWith({ teamId, type })).to.be.true;
+		});
+
+		it("should return empty results for non-existent team", async () => {
+			// Arrange
+			monitorFindStub.resolves([]);
+
+			// Act
+			const result = await getMonitorsAndSummaryByTeamId("nonexistent", "http");
+
+			// Assert
+			expect(result.monitors).to.have.lengthOf(0);
+			expect(result.monitorCounts).to.deep.equal({
+				up: 0,
+				down: 0,
+				paused: 0,
+				total: 0,
+			});
+		});
+
+		it("should handle database errors", async () => {
+			// Arrange
+			const error = new Error("Database error");
+			error.service = "MonitorModule";
+			error.method = "getMonitorsAndSummaryByTeamId";
+			monitorFindStub.rejects(error);
+
+			// Act & Assert
+			try {
+				await getMonitorsAndSummaryByTeamId("team123", "http");
+				expect.fail("Should have thrown an error");
+			} catch (err) {
+				expect(err).to.equal(error);
+				expect(err.service).to.equal("monitorModule");
+				expect(err.method).to.equal("getMonitorsAndSummaryByTeamId");
+			}
+		});
+	});
+	describe("getMonitorsByTeamId", () => {
+		beforeEach(() => {
+			// Chain stubs for Monitor.find().skip().limit().sort()
+
+			// Stub for CHECK_MODEL_LOOKUP model find
+			checkFindStub.returns({
+				sort: sinon.stub().returnsThis(),
+				limit: sinon.stub().returnsThis(),
+			});
+		});
+
+		afterEach(() => {
+			sinon.restore();
+		});
+
+		it("should return monitors with basic query parameters", async () => {
+			const mockMonitors = [
+				{ _id: "1", type: "http", toObject: () => ({ _id: "1", type: "http" }) },
+				{ _id: "2", type: "ping", toObject: () => ({ _id: "2", type: "ping" }) },
+			];
+			monitorFindStub.returns({
+				skip: sinon.stub().returns({
+					limit: sinon.stub().returns({
+						sort: sinon.stub().returns(mockMonitors),
+					}),
+				}),
+			});
+
+			const req = {
+				params: { teamId: "team123" },
+				query: {
+					page: 0,
+					rowsPerPage: 10,
+				},
+			};
+
+			monitorCountStub.resolves(2);
+
+			const result = await getMonitorsByTeamId(req);
+
+			expect(result).to.have.property("monitors");
+			expect(result).to.have.property("monitorCount", 2);
+		});
+
+		it("should handle type filter with array input", async () => {
+			const req = {
+				params: { teamId: "team123" },
+				query: {
+					type: ["http", "ping"],
+				},
+			};
+
+			monitorFindStub.returns({
+				skip: sinon.stub().returns({
+					limit: sinon.stub().returns({
+						sort: sinon.stub().returns([]),
+					}),
+				}),
+			});
+			monitorCountStub.resolves(0);
+
+			await getMonitorsByTeamId(req);
+
+			expect(Monitor.find.firstCall.args[0]).to.deep.equal({
+				teamId: "team123",
+				type: { $in: ["http", "ping"] },
+			});
+		});
+
+		it("should handle text search filter", async () => {
+			const req = {
+				params: { teamId: "team123" },
+				query: {
+					filter: "search",
+				},
+			};
+
+			monitorFindStub.returns({
+				skip: sinon.stub().returns({
+					limit: sinon.stub().returns({
+						sort: sinon.stub().returns([]),
+					}),
+				}),
+			});
+			monitorCountStub.resolves(0);
+
+			await getMonitorsByTeamId(req);
+
+			expect(Monitor.find.firstCall.args[0]).to.deep.equal({
+				teamId: "team123",
+				$or: [
+					{ name: { $regex: "search", $options: "i" } },
+					{ url: { $regex: "search", $options: "i" } },
+				],
+			});
+		});
+
+		it("should handle pagination parameters", async () => {
+			const req = {
+				params: { teamId: "team123" },
+				query: {
+					page: 2,
+					rowsPerPage: 5,
+				},
+			};
+
+			monitorFindStub.returns({
+				skip: sinon.stub().returns({
+					limit: sinon.stub().returns({
+						sort: sinon.stub().returns([]),
+					}),
+				}),
+			});
+			monitorCountStub.resolves(0);
+
+			const result = await getMonitorsByTeamId(req);
+			expect(result).to.deep.equal({
+				monitors: [],
+				monitorCount: 0,
+			});
+		});
+
+		it("should handle sorting parameters", async () => {
+			const req = {
+				params: { teamId: "team123" },
+				query: {
+					field: "name",
+					order: "asc",
+				},
+			};
+
+			monitorFindStub.returns({
+				skip: sinon.stub().returns({
+					limit: sinon.stub().returns({
+						sort: sinon.stub().returns([]),
+					}),
+				}),
+			});
+			monitorCountStub.resolves(0);
+
+			await getMonitorsByTeamId(req);
+
+			const result = await getMonitorsByTeamId(req);
+			expect(result).to.deep.equal({
+				monitors: [],
+				monitorCount: 0,
+			});
+		});
+
+		it("should return early when limit is -1", async () => {
+			// Arrange
+			const req = {
+				params: { teamId: "team123" },
+				query: {
+					limit: "-1",
+				},
+			};
+
+			const mockMonitors = [
+				{ _id: "1", type: "http" },
+				{ _id: "2", type: "ping" },
+			];
+
+			monitorFindStub.returns({
+				skip: sinon.stub().returns({
+					limit: sinon.stub().returns({
+						sort: sinon.stub().returns(mockMonitors),
+					}),
+				}),
+			});
+
+			monitorCountStub.resolves(2);
+
+			// Act
+			const result = await getMonitorsByTeamId(req);
+
+			// Assert
+			expect(result).to.deep.equal({
+				monitors: mockMonitors,
+				monitorCount: 2,
+			});
+		});
+		it("should normalize checks when normalize parameter is provided", async () => {
+			const req = {
+				params: { teamId: "team123" },
+				query: { normalize: "true" },
+			};
+
+			const mockMonitors = [
+				{ _id: "1", type: "http" },
+				{ _id: "2", type: "ping" },
+			];
+
+			monitorFindStub.returns({
+				skip: sinon.stub().returns({
+					limit: sinon.stub().returns({
+						sort: sinon.stub().returns(mockMonitors),
+					}),
+				}),
+			});
+
+			const result = await getMonitorsByTeamId(req);
+
+			expect(NormalizeDataStub.calledOnce).to.be.true;
+			expect(NormalizeDataStub.firstCall.args[0]).to.deep.equal([{ responseTime: 100 }]);
+			expect(NormalizeDataStub.firstCall.args[1]).to.equal(10);
+			expect(NormalizeDataStub.firstCall.args[2]).to.equal(100);
+		});
+		it("should handle database errors", async () => {
+			// Arrange
+			const req = {
+				params: { teamId: "team123" },
+				query: {},
+			};
+
+			const error = new Error("Database error");
+			monitorFindStub.returns({
+				skip: sinon.stub().returns({
+					limit: sinon.stub().returns({
+						sort: sinon.stub().throws(error),
+					}),
+				}),
+			});
+
+			// Act & Assert
+			try {
+				await getMonitorsByTeamId(req);
+				expect.fail("Should have thrown an error");
+			} catch (err) {
+				expect(err.service).to.equal("monitorModule");
+				expect(err.method).to.equal("getMonitorsByTeamId");
+				expect(err.message).to.equal("Database error");
+			}
+		});
+	});
+	describe("createMonitor", () => {
+		it("should create a monitor without notifications", async () => {
+			let monitorSaveStub = sinon.stub(Monitor.prototype, "save").resolves();
+
+			const req = {
+				body: {
+					name: "Test Monitor",
+					url: "http://test.com",
+					type: "http",
+					notifications: ["someNotification"],
+				},
+			};
+
+			const expectedMonitor = {
+				name: "Test Monitor",
+				url: "http://test.com",
+				type: "http",
+				notifications: undefined,
+				save: monitorSaveStub,
+			};
+
+			const result = await createMonitor(req);
+			expect(result.name).to.equal(expectedMonitor.name);
+			expect(result.url).to.equal(expectedMonitor.url);
+		});
+		it("should handle database errors", async () => {
+			const req = {
+				body: {
+					name: "Test Monitor",
+				},
+			};
+
+			try {
+				await createMonitor(req);
+				expect.fail("Should have thrown an error");
+			} catch (err) {
+				expect(err.service).to.equal("monitorModule");
+				expect(err.method).to.equal("createMonitor");
+			}
+		});
+	});
+
+	describe("deleteMonitor", () => {
+		it("should delete a monitor successfully", async () => {
+			const monitorId = "123456789";
+			const mockMonitor = {
+				_id: monitorId,
+				name: "Test Monitor",
+				url: "http://test.com",
+			};
+
+			const req = {
+				params: { monitorId },
+			};
+
+			monitorFindByIdAndDeleteStub.resolves(mockMonitor);
+
+			const result = await deleteMonitor(req);
+
+			expect(result).to.deep.equal(mockMonitor);
+			sinon.assert.calledWith(monitorFindByIdAndDeleteStub, monitorId);
+		});
+
+		it("should throw error when monitor not found", async () => {
+			const monitorId = "nonexistent123";
+			const req = {
+				params: { monitorId },
+			};
+
+			monitorFindByIdAndDeleteStub.resolves(null);
+
+			try {
+				await deleteMonitor(req);
+				expect.fail("Should have thrown an error");
+			} catch (err) {
+				expect(err.message).to.equal(errorMessages.DB_FIND_MONITOR_BY_ID(monitorId));
+				expect(err.service).to.equal("monitorModule");
+				expect(err.method).to.equal("deleteMonitor");
+			}
+		});
+
+		it("should handle database errors", async () => {
+			const monitorId = "123456789";
+			const req = {
+				params: { monitorId },
+			};
+
+			const dbError = new Error("Database connection error");
+			monitorFindByIdAndDeleteStub.rejects(dbError);
+
+			try {
+				await deleteMonitor(req);
+				expect.fail("Should have thrown an error");
+			} catch (err) {
+				expect(err.message).to.equal("Database connection error");
+				expect(err.service).to.equal("monitorModule");
+				expect(err.method).to.equal("deleteMonitor");
+			}
+		});
+	});
+
+	describe("deleteAllMonitors", () => {
+		it("should delete all monitors for a team successfully", async () => {
+			const teamId = "team123";
+			const mockMonitors = [
+				{ _id: "1", name: "Monitor 1", teamId },
+				{ _id: "2", name: "Monitor 2", teamId },
+			];
+
+			monitorFindStub.resolves(mockMonitors);
+			monitorDeleteManyStub.resolves({ deletedCount: 2 });
+
+			const result = await deleteAllMonitors(teamId);
+
+			expect(result).to.deep.equal({
+				monitors: mockMonitors,
+				deletedCount: 2,
+			});
+			sinon.assert.calledWith(monitorFindStub, { teamId });
+			sinon.assert.calledWith(monitorDeleteManyStub, { teamId });
+		});
+
+		it("should return empty array when no monitors found", async () => {
+			const teamId = "emptyTeam";
+
+			monitorFindStub.resolves([]);
+			monitorDeleteManyStub.resolves({ deletedCount: 0 });
+
+			const result = await deleteAllMonitors(teamId);
+
+			expect(result).to.deep.equal({
+				monitors: [],
+				deletedCount: 0,
+			});
+			sinon.assert.calledWith(monitorFindStub, { teamId });
+			sinon.assert.calledWith(monitorDeleteManyStub, { teamId });
+		});
+
+		it("should handle database errors", async () => {
+			const teamId = "team123";
+			const dbError = new Error("Database connection error");
+			monitorFindStub.rejects(dbError);
+
+			try {
+				await deleteAllMonitors(teamId);
+			} catch (err) {
+				expect(err.message).to.equal("Database connection error");
+				expect(err.service).to.equal("monitorModule");
+				expect(err.method).to.equal("deleteAllMonitors");
+			}
+		});
+
+		it("should handle deleteMany errors", async () => {
+			const teamId = "team123";
+			monitorFindStub.resolves([{ _id: "1", name: "Monitor 1" }]);
+			monitorDeleteManyStub.rejects(new Error("Delete operation failed"));
+
+			try {
+				await deleteAllMonitors(teamId);
+			} catch (err) {
+				expect(err.message).to.equal("Delete operation failed");
+				expect(err.service).to.equal("monitorModule");
+				expect(err.method).to.equal("deleteAllMonitors");
+			}
+		});
+	});
+
+	describe("deleteMonitorsByUserId", () => {
+		beforeEach(() => {});
+
+		afterEach(() => {
+			sinon.restore();
+		});
+
+		it("should delete all monitors for a user successfully", async () => {
+			// Arrange
+			const userId = "user123";
+			const mockResult = {
+				deletedCount: 3,
+				acknowledged: true,
+			};
+
+			monitorDeleteManyStub.resolves(mockResult);
+
+			// Act
+			const result = await deleteMonitorsByUserId(userId);
+
+			// Assert
+			expect(result).to.deep.equal(mockResult);
+			sinon.assert.calledWith(monitorDeleteManyStub, { userId: userId });
+		});
+
+		it("should return zero deletedCount when no monitors found", async () => {
+			// Arrange
+			const userId = "nonexistentUser";
+			const mockResult = {
+				deletedCount: 0,
+				acknowledged: true,
+			};
+
+			monitorDeleteManyStub.resolves(mockResult);
+
+			// Act
+			const result = await deleteMonitorsByUserId(userId);
+
+			// Assert
+			expect(result.deletedCount).to.equal(0);
+			sinon.assert.calledWith(monitorDeleteManyStub, { userId: userId });
+		});
+
+		it("should handle database errors", async () => {
+			// Arrange
+			const userId = "user123";
+			const dbError = new Error("Database connection error");
+			monitorDeleteManyStub.rejects(dbError);
+
+			// Act & Assert
+			try {
+				await deleteMonitorsByUserId(userId);
+				expect.fail("Should have thrown an error");
+			} catch (err) {
+				expect(err.message).to.equal("Database connection error");
+				expect(err.service).to.equal("monitorModule");
+				expect(err.method).to.equal("deleteMonitorsByUserId");
+			}
+		});
+	});
+
+	describe("editMonitor", () => {
+		it("should edit a monitor successfully", async () => {
+			// Arrange
+			const candidateId = "monitor123";
+			const candidateMonitor = {
+				name: "Updated Monitor",
+				url: "http://updated.com",
+				type: "http",
+				notifications: ["someNotification"],
+			};
+
+			const expectedUpdateData = {
+				name: "Updated Monitor",
+				url: "http://updated.com",
+				type: "http",
+				notifications: undefined,
+			};
+
+			const mockUpdatedMonitor = {
+				_id: candidateId,
+				...expectedUpdateData,
+			};
+
+			monitorFindByIdAndUpdateStub.resolves(mockUpdatedMonitor);
+
+			// Act
+			const result = await editMonitor(candidateId, candidateMonitor);
+
+			// Assert
+			expect(result).to.deep.equal(mockUpdatedMonitor);
+			sinon.assert.calledWith(
+				monitorFindByIdAndUpdateStub,
+				candidateId,
+				expectedUpdateData,
+				{
+					new: true,
+				}
+			);
+		});
+
+		it("should return null when monitor not found", async () => {
+			// Arrange
+			const candidateId = "nonexistent123";
+			const candidateMonitor = {
+				name: "Updated Monitor",
+			};
+
+			monitorFindByIdAndUpdateStub.resolves(null);
+
+			// Act
+			const result = await editMonitor(candidateId, candidateMonitor);
+
+			// Assert
+			expect(result).to.be.null;
+			sinon.assert.calledWith(
+				monitorFindByIdAndUpdateStub,
+				candidateId,
+				{ name: "Updated Monitor", notifications: undefined },
+				{ new: true }
+			);
+		});
+
+		it("should remove notifications from update data", async () => {
+			// Arrange
+			const candidateId = "monitor123";
+			const candidateMonitor = {
+				name: "Updated Monitor",
+				notifications: ["notification1", "notification2"],
+			};
+
+			const expectedUpdateData = {
+				name: "Updated Monitor",
+				notifications: undefined,
+			};
+
+			monitorFindByIdAndUpdateStub.resolves({
+				_id: candidateId,
+				...expectedUpdateData,
+			});
+
+			// Act
+			await editMonitor(candidateId, candidateMonitor);
+
+			// Assert
+			sinon.assert.calledWith(
+				monitorFindByIdAndUpdateStub,
+				candidateId,
+				expectedUpdateData,
+				{
+					new: true,
+				}
+			);
+		});
+
+		it("should handle database errors", async () => {
+			// Arrange
+			const candidateId = "monitor123";
+			const candidateMonitor = {
+				name: "Updated Monitor",
+			};
+
+			const dbError = new Error("Database connection error");
+			monitorFindByIdAndUpdateStub.rejects(dbError);
+
+			// Act & Assert
+			try {
+				await editMonitor(candidateId, candidateMonitor);
+				expect.fail("Should have thrown an error");
+			} catch (err) {
+				expect(err.message).to.equal("Database connection error");
+				expect(err.service).to.equal("monitorModule");
+				expect(err.method).to.equal("editMonitor");
+			}
+		});
+	});
+
+	describe("addDemoMonitors", () => {
+		it("should add demo monitors successfully", async () => {
+			// Arrange
+			const userId = "user123";
+			const teamId = "team123";
+			monitorInsertManyStub.resolves([{ _id: "123" }]);
+			const result = await addDemoMonitors(userId, teamId);
+			expect(result).to.deep.equal([{ _id: "123" }]);
+		});
+
+		it("should handle database errors", async () => {
+			const userId = "user123";
+			const teamId = "team123";
+
+			const dbError = new Error("Database connection error");
+			monitorInsertManyStub.rejects(dbError);
+
+			try {
+				await addDemoMonitors(userId, teamId);
+			} catch (err) {
+				expect(err.message).to.equal("Database connection error");
+				expect(err.service).to.equal("monitorModule");
+				expect(err.method).to.equal("addDemoMonitors");
+			}
+		});
+	});
+});

--- a/Server/tests/services/statusService.test.js
+++ b/Server/tests/services/statusService.test.js
@@ -98,6 +98,7 @@ describe("StatusService", () => {
 			expect(check.responseTime).to.equal(100);
 			expect(check.message).to.equal("Test message");
 		});
+
 		it("should build a check object for pagespeed type", () => {
 			const check = statusService.buildCheck({
 				monitorId: "test",
@@ -192,6 +193,26 @@ describe("StatusService", () => {
 			expect(check.memory).to.equal("memory");
 			expect(check.disk).to.equal("disk");
 			expect(check.host).to.equal("host");
+		});
+		it("should build a check for hardware type with missing data", () => {
+			const check = statusService.buildCheck({
+				monitorId: "test",
+				type: "hardware",
+				status: true,
+				responseTime: 100,
+				code: 200,
+				message: "Test message",
+				payload: {},
+			});
+			expect(check.monitorId).to.equal("test");
+			expect(check.status).to.be.true;
+			expect(check.statusCode).to.equal(200);
+			expect(check.responseTime).to.equal(100);
+			expect(check.message).to.equal("Test message");
+			expect(check.cpu).to.deep.equal({});
+			expect(check.memory).to.deep.equal({});
+			expect(check.disk).to.deep.equal({});
+			expect(check.host).to.deep.equal({});
 		});
 	});
 	describe("insertCheck", () => {


### PR DESCRIPTION
This PR implements the feature requested in discussion #1115

- [x] Add new route `/api/v1/monitors/uptime`
- [x] Add controller method for this route
  - [x] Add tests for controller
- [x] Add db method for this new route
  - [x] Add tests for DB method
  
 It also adds a missing test case for `statusService` and updates test runner configuration to run DB tests
