### PR TITLE
feat: Ntfy support for incident notifications added

### DIFF
--- a/Client/src/Pages/Monitors/CreateMonitor/index.jsx
+++ b/Client/src/Pages/Monitors/CreateMonitor/index.jsx
@@ -17,14 +17,28 @@ import Checkbox from "../../../Components/Inputs/Checkbox";
 import Breadcrumbs from "../../../Components/Breadcrumbs";
 import { getUptimeMonitorById } from "../../../Features/UptimeMonitors/uptimeMonitorsSlice";
 import "./index.css";
+import axios from "axios";
 
 const CreateMonitor = () => {
-  const MS_PER_MINUTE = 60000;
-  const { user, authToken } = useSelector((state) => state.auth);
-  const { monitors, isLoading } = useSelector((state) => state.uptimeMonitors);
-  const dispatch = useDispatch();
-  const navigate = useNavigate();
-  const theme = useTheme();
+	const MS_PER_MINUTE = 60000;
+	const { user, authToken } = useSelector((state) => state.auth);
+	const { monitors, isLoading } = useSelector((state) => state.uptimeMonitors);
+	const [ntfyLoading, setntfyLoading] = useState(false)
+	const [showNtfySettings, setShowNtfySettings] = useState(false)
+	const dispatch = useDispatch();
+	const navigate = useNavigate();
+	const theme = useTheme();
+	// Ntfy settings
+	const [ntfySettings, setNtfySettings] = useState({
+		friendlyName: "",
+		topic: "",
+		serverUrl: "https://ntfy.sh", // Default value
+		priority: "5",
+		authMode: "no-auth", // Default authentication mode
+		username: "",
+		password: "",
+		accessToken: "",
+	});
 
 	const idMap = {
 		"monitor-url": "url",
@@ -42,6 +56,14 @@ const CreateMonitor = () => {
 		notifications: [],
 		interval: 1,
 	});
+
+	// Auth options for ntfy
+	const authOptions = [
+		{ _id: 'no-auth', name: 'No auth' },
+		{ _id: 'user-pass', name: 'Username and Password' },
+		{ _id: 'accessToken', name: 'Access Token' }
+	];
+
 	const [https, setHttps] = useState(true);
 	const [errors, setErrors] = useState({});
 
@@ -73,6 +95,14 @@ const CreateMonitor = () => {
 		fetchMonitor();
 	}, [monitorId, authToken, monitors]);
 
+	//Handles changes for ntfy settings
+	const handleChangeNtfy = (field, value) => {
+		setNtfySettings(prev => ({
+			...prev,
+			[field]: value
+		}));
+	};
+
 	const handleChange = (event, name) => {
 		const { value, id } = event.target;
 		if (!name) name = idMap[id];
@@ -97,7 +127,7 @@ const CreateMonitor = () => {
 							name === "email"
 								? { type: name, address: value }
 								: // TODO - phone number
-									{ type: name, phone: value },
+								{ type: name, phone: value },
 						],
 					};
 				}
@@ -121,6 +151,75 @@ const CreateMonitor = () => {
 			});
 		}
 	};
+
+	// Handler for adding Ntfy notification to monitor
+	const handleChangeForNtfy = () => {
+		setntfyLoading(true);
+		setMonitor((prev) => {
+			const notifs = [...prev.notifications];
+
+			return {
+				...prev,
+				notifications: [
+					...notifs,
+					{ type: "ntfy", ntfyConfig: ntfySettings }
+				],
+			};
+		});
+		createToast({ body: "Ntfy notification added successfully" });
+		setntfyLoading(false);
+	}
+
+	// Handler for Testing Ntfy notification
+	const testNotification = async () => {
+		try {
+			// Set up authorization headers based on authMode
+			let headers = {
+				Title: ntfySettings.friendlyName || `Monitor Alert`,
+				Priority: ntfySettings.priority,
+				Tags: "warning",
+				"Content-Type": "text/plain",
+			};
+
+			if (
+				ntfySettings.authMode === "user-pass" &&
+				ntfySettings.username &&
+				ntfySettings.password
+			) {
+				headers.Authorization =
+					"Basic " +
+					Buffer.from(`${ntfySettings.username}:${ntfySettings.password}`).toString(
+						"base64"
+					);
+			} else if (ntfySettings.authMode === "accessToken" && ntfySettings.accessToken) {
+				headers.Authorization = "Bearer " + ntfySettings.accessToken;
+			}
+
+			// Ensure the server URL does not have a trailing slash
+			const serverUrl = ntfySettings.serverUrl.endsWith("/")
+				? ntfySettings.serverUrl.slice(0, -1)
+				: ntfySettings.serverUrl;
+
+			// Plain text body message
+			const ntfyBody = "This is a test message from your Ntfy setup.";
+
+			// Send the Ntfy notification
+			const response = await axios.post(`${serverUrl}/${ntfySettings.topic}`, ntfyBody, {
+				headers,
+			});
+
+			if (response.status === 200) {
+				createToast({
+					body: "Notification sent successfully",
+				});
+			}
+		} catch (error) {
+			createToast({
+				body: `Failed to send notification with ${error}`,
+			});
+		}
+	};
+
 
 	const handleCreateMonitor = async (event) => {
 		event.preventDefault();
@@ -148,16 +247,16 @@ const CreateMonitor = () => {
 			setErrors(newErrors);
 			createToast({ body: "Error validation data." });
 		} else {
-      if (monitor.type === "http") {
-        const checkEndpointAction = await dispatch(
-          checkEndpointResolution({ authToken, monitorURL: form.url })
-        )
-        if (checkEndpointAction.meta.requestStatus === "rejected") {
-          createToast({ body: "The endpoint you entered doesn't resolve. Check the URL again." });
-          setErrors({ url: "The entered URL is not reachable." });
-          return;
-        }
-      }
+			if (monitor.type === "http") {
+				const checkEndpointAction = await dispatch(
+					checkEndpointResolution({ authToken, monitorURL: form.url })
+				)
+				if (checkEndpointAction.meta.requestStatus === "rejected") {
+					createToast({ body: "The endpoint you entered doesn't resolve. Check the URL again." });
+					setErrors({ url: "The entered URL is not reachable." });
+					return;
+				}
+			}
 
 			form = {
 				...form,
@@ -341,6 +440,114 @@ const CreateMonitor = () => {
 							onChange={(event) => handleChange(event)}
 						/>
 						<Checkbox
+							id="notify-via-ntfy"
+							label="Notify via ntfy.sh"
+							isChecked={showNtfySettings}
+							onChange={() => setShowNtfySettings(prev => !prev)}
+							value=""
+						/>
+						{/* Ntfy-specific fields: Render when ntfy is selected */}
+						{showNtfySettings === true && (
+							<Box sx={{ mt: 2 }}>
+								<Stack spacing={3}>
+									<Field
+										id="ntfy-friendly-name"
+										type="text"
+										label="Friendly name"
+										placeholder="Enter a friendly name"
+										value={ntfySettings.friendlyName}
+										onChange={(e) => handleChangeNtfy('friendlyName', e.target.value)}
+									/>
+									<Field
+										id="ntfy-topic"
+										type="text"
+										label="Topic"
+										placeholder="Enter ntfy topic"
+										value={ntfySettings.topic}
+										onChange={(e) => handleChangeNtfy('topic', e.target.value)}
+									/>
+									<Field
+										id="ntfy-server-url"
+										type="text"
+										label="Server URL"
+										placeholder="https://ntfy.sh"
+										value={ntfySettings.serverUrl}
+										onChange={(e) => handleChangeNtfy('serverUrl', e.target.value)}
+									/>
+									<Field
+										id="ntfy-priority"
+										type="number"
+										label="Priority"
+										min="1"
+										max="5"
+										placeholder="1-5"
+										value={ntfySettings.priority}
+										onChange={(e) => handleChangeNtfy('priority', e.target.value)}
+									/>
+									<Select
+										id="auth-select"
+										label="Authentication Method"
+										value={ntfySettings.authMode}
+										onChange={(e) => handleChangeNtfy('authMode', e.target.value)}
+										items={authOptions}
+									/>
+									{ntfySettings.authMode === "user-pass" && (
+										<>
+											<Field
+												id="ntfy-username"
+												type="text"
+												label="Username"
+												placeholder="Enter username"
+												value={ntfySettings.username}
+												onChange={(e) => handleChangeNtfy('username', e.target.value)}
+											/>
+											<Field
+												id="ntfy-password"
+												type="password"
+												label="Password"
+												placeholder="Enter password"
+												value={ntfySettings.password}
+												onChange={(e) => handleChangeNtfy('password', e.target.value)}
+											/>
+										</>
+									)}
+									{ntfySettings.authMode === "accessToken" && (
+										<Field
+											id="ntfy-access-token"
+											type="text"
+											label="Access Token"
+											placeholder="Enter access token"
+											value={ntfySettings.accessToken}
+											onChange={(e) => handleChangeNtfy('accessToken', e.target.value)}
+										/>
+									)}
+									<Stack
+										direction="row"
+										spacing={2}
+									>
+										<LoadingButton
+											variant="contained"
+											color="primary"
+											onClick={testNotification}
+											disabled={Object.keys(errors).length !== 0}
+											loading={ntfyLoading}
+										>
+											Test
+										</LoadingButton>
+										<LoadingButton
+											variant="contained"
+											color="primary"
+											onClick={handleChangeForNtfy}
+											disabled={Object.keys(errors).length !== 0}
+											loading={isLoading}
+										>
+											Save
+										</LoadingButton>
+									</Stack>
+								</Stack>
+							</Box>
+						)}
+						<Checkbox
 							id="notify-email"
 							label="Also notify via email to multiple addresses (coming soon)"
 							isChecked={false}
@@ -386,15 +593,15 @@ const CreateMonitor = () => {
 					direction="row"
 					justifyContent="flex-end"
 				>
-					<LoadingButton 
-            variant="contained"
-            color="primary"
-            onClick={handleCreateMonitor}
-            disabled={Object.keys(errors).length !== 0 && true}
-            loading={isLoading}
-          >
-            Create monitor
-          </LoadingButton>
+					<LoadingButton
+						variant="contained"
+						color="primary"
+						onClick={handleCreateMonitor}
+						disabled={Object.keys(errors).length !== 0 && true}
+						loading={isLoading}
+					>
+						Create monitor
+					</LoadingButton>
 				</Stack>
 			</Stack>
 		</Box>

--- a/Server/db/models/Notification.js
+++ b/Server/db/models/Notification.js
@@ -8,7 +8,10 @@ const NotificationSchema = mongoose.Schema(
 		},
 		type: {
 			type: String,
-			enum: ["email", "sms"],
+			enum: ["email", "sms", "ntfy"],
+		},
+		ntfyConfig: {
+			type: Object,
 		},
 		address: {
 			type: String,

--- a/Server/index.js
+++ b/Server/index.js
@@ -44,6 +44,7 @@ import StatusService from "./service/statusService.js";
 import NotificationService from "./service/notificationService.js";
 
 import db from "./db/mongo/MongoDB.js";
+import NtfyService from "./service/ntfyService.js";
 const SERVICE_NAME = "Server";
 
 let cleaningUp = false;
@@ -128,9 +129,10 @@ const startApp = async () => {
 		nodemailer,
 		logger
 	);
+	const ntfyService = new NtfyService(logger);
 	const networkService = new NetworkService(axios, ping, logger, http);
 	const statusService = new StatusService(db, logger);
-	const notificationService = new NotificationService(emailService, db, logger);
+	const notificationService = new NotificationService(emailService, db, logger, ntfyService);
 	const jobQueue = await JobQueue.createJobQueue(
 		db,
 		networkService,

--- a/Server/service/notificationService.js
+++ b/Server/service/notificationService.js
@@ -6,11 +6,12 @@ class NotificationService {
 	 * @param {Object} db - The database instance for storing notification data.
 	 * @param {Object} logger - The logger instance for logging activities.
 	 */
-	constructor(emailService, db, logger) {
+	constructor(emailService, db, logger, ntfyService) {
 		this.SERVICE_NAME = "NotificationService";
 		this.emailService = emailService;
 		this.db = db;
 		this.logger = logger;
+		this.ntfyService = ntfyService;
 	}
 
 	/**
@@ -48,6 +49,9 @@ class NotificationService {
 					this.sendEmail(networkResponse, notification.address);
 				}
 				// Handle other types of notifications here
+				else if (notification.type === "ntfy") {
+					await this.ntfyService.sendNtfyNotification(notification.ntfyConfig, networkResponse);
+				}
 			}
 		} catch (error) {
 			this.logger.warn({

--- a/Server/service/ntfyService.js
+++ b/Server/service/ntfyService.js
@@ -1,0 +1,77 @@
+import axios from "axios";
+
+class NtfyService {
+	constructor(logger) {
+		this.logger = logger;
+		this.SERVICE_NAME = "NtfyService";
+	}
+
+	/**
+	 * Sends a Ntfy notification.
+	 *
+	 * @param {Object} ntfyConfig - Configuration for Ntfy.
+	 * @param {string} ntfyConfig.topic - The Ntfy topic.
+	 * @param {string} ntfyConfig.serverUrl - The server URL for Ntfy.
+	 * @param {string} ntfyConfig.friendlyName - A friendly name for the notification.
+	 * @param {string} ntfyConfig.priority - Priority of the notification.
+	 * @param {string} ntfyConfig.authMode - Authentication mode ("no-auth" or user-pass" or "accessToken").
+	 */
+	async sendNtfyNotification(ntfyConfig, networkResponse) {
+		const { monitor, status } = networkResponse;
+		try {
+			// Set up authorization headers based on authMode
+			let headers = {
+				Title: ntfyConfig.friendlyName || `Monitor Alert`,
+				Priority: ntfyConfig.priority,
+				Tags: "warning",
+				"Content-Type": "text/plain",
+			};
+
+			if (
+				ntfyConfig.authMode === "user-pass" &&
+				ntfyConfig.username &&
+				ntfyConfig.password
+			) {
+				headers.Authorization =
+					"Basic " +
+					Buffer.from(`${ntfyConfig.username}:${ntfyConfig.password}`).toString(
+						"base64"
+					);
+			} else if (ntfyConfig.authMode === "accessToken" && ntfyConfig.accessToken) {
+				headers.Authorization = "Bearer " + ntfyConfig.accessToken;
+			}
+
+			// Ensure the server URL does not have a trailing slash
+			const serverUrl = ntfyConfig.serverUrl.endsWith("/")
+				? ntfyConfig.serverUrl.slice(0, -1)
+				: ntfyConfig.serverUrl;
+
+			// Plain text body message
+			const ntfyBody = `Status of ${monitor.name} is ${status ? "up" : "down"}`;
+
+			// Send the Ntfy notification
+			const response = await axios.post(`${serverUrl}/${ntfyConfig.topic}`, ntfyBody, {
+				headers,
+			});
+
+			if (response.status === 200) {
+				this.logger.info({
+					service: this.SERVICE_NAME,
+					message: "Ntfy notification sent successfully",
+				});
+			} else {
+				this.logger.error({
+					service: this.SERVICE_NAME,
+					message: "An error occurred while sending notification",
+				});
+			}
+		} catch (error) {
+			this.logger.error(`Failed to send Ntfy notification: ${error.message}`, {
+				service: this.SERVICE_NAME,
+				method: "sendNtfyNotification",
+			});
+		}
+	}
+}
+
+export default NtfyService;


### PR DESCRIPTION
Closes #702 
### Add ntfy.sh as a New Notification Provider

This PR introduces [ntfy.sh](https://ntfy.sh/) as a new notification provider alongside existing email option.

Implementation is according to draft discussed in #702 

### Changes

- Added ntfy as a new notification type along with the config object in the notification model

```
       ...
	type: {
		type: String,
		enum: ["email", "sms", "ntfy"],
	},
	ntfyConfig: {
		type: Object,
	}
	...
```
- Implemented NtfyService class for handling ntfy.sh notifications
The NtfyService class implements ntfy.sh notification handling with support for multiple authentication methods (no-auth, user-pass, access token). It prepares notifications with customizable headers including title, priority, and tags, while handling URL sanitization and proper error logging. The service sends monitor status updates via HTTP POST requests, with the message body indicating whether a monitored service is up or down.

- Extended notification service to handle ntfy notifications
In the handleNotifications method, ntfyService being injected through the constructor, when processing notifications of type "ntfy", it delegates the notification sending to the ntfyService by calling sendNtfyNotification with the appropriate configuration and network response data.

- Updated monitor creation and configuration UI to support ntfy settings
On the UI side, a checkbox of "Notify via ntfy.sh" is shown in the incidents section which on enabling will request users to enter required fields like friendly name, topic, server url, priority and authentication mode.

![Screenshot 2024-11-10 at 18-09-55 BlueWave Uptime](https://github.com/user-attachments/assets/84d9d66d-84c0-48ed-bb2f-7485477f1dea)


- Output in ntfy mobile app
![WhatsApp Image 2024-11-10 at 6 12 16 PM](https://github.com/user-attachments/assets/cc5b6e37-c5e4-43f6-a296-905fc4fda166)

### Test Checklist
- [X] Basic notification works (monitor down/up triggers ntfy notification)
- [X] All auth modes work (no-auth, user/pass, access token)
- [X] Form validation and error handling works as expected
- [X] Notification settings persist after save/reload
- [X] Coexists with email notifications without conflicts

Let me know if any further refinements are required!
