### PR TITLE
feat/be/hardware monitor update

### DIFF
--- a/Server/db/models/HardwareCheck.js
+++ b/Server/db/models/HardwareCheck.js
@@ -30,6 +30,11 @@ const hostSchema = mongoose.Schema({
 	kernel_version: { type: String, default: "" },
 });
 
+const errorSchema = mongoose.Schema({
+	metric: { type: [String], default: [] },
+	err: { type: String, default: "" },
+});
+
 const HardwareCheckSchema = mongoose.Schema(
 	{
 		...BaseCheckSchema.obj,
@@ -48,6 +53,10 @@ const HardwareCheckSchema = mongoose.Schema(
 		host: {
 			type: hostSchema,
 			default: () => ({}),
+		},
+		errors: {
+			type: [errorSchema],
+			default: () => [],
 		},
 	},
 	{ timestamps: true }

--- a/Server/service/statusService.js
+++ b/Server/service/statusService.js
@@ -83,6 +83,7 @@ class StatusService {
 			responseTime,
 			message,
 		};
+
 		if (type === "pagespeed") {
 			const categories = payload.lighthouseResult?.categories;
 			const audits = payload.lighthouseResult?.audits;
@@ -101,10 +102,13 @@ class StatusService {
 		}
 
 		if (type === "hardware") {
-			check.cpu = payload?.cpu ?? {};
-			check.memory = payload?.memory ?? {};
-			check.disk = payload?.disk ?? {};
-			check.host = payload?.host ?? {};
+			const { cpu, memory, disk, host } = payload?.data ?? {};
+			const { errors } = payload;
+			check.cpu = cpu ?? {};
+			check.memory = memory ?? {};
+			check.disk = disk ?? {};
+			check.host = host ?? {};
+			check.errors = errors ?? [];
 		}
 		return check;
 	};
@@ -131,6 +135,7 @@ class StatusService {
 				hardware: this.db.createHardwareCheck,
 			};
 			const operation = operationMap[networkResponse.type];
+
 			const check = this.buildCheck(networkResponse);
 			await operation(check);
 		} catch (error) {


### PR DESCRIPTION
This PR updates the hardware check schema and `StatusService` to handle changes made to the [Monitoring Agent](https://github.com/bluewave-labs/bluewave-uptime-agent)

- [x] Update hardware check schema to reflect changes to Monitoring Agent
  - [x] Hardware check schema now includes errors returned with a hardware check
- [x] Update `StatusService` to handle new hardware check schema properly  