### PR TITLE
feat/be/docker monitors, references #1139

### DIFF
--- a/Server/db/models/Monitor.js
+++ b/Server/db/models/Monitor.js
@@ -28,7 +28,7 @@ const MonitorSchema = mongoose.Schema(
 		type: {
 			type: String,
 			required: true,
-			enum: ["http", "ping", "pagespeed", "hardware"],
+			enum: ["http", "ping", "pagespeed", "hardware", "docker"],
 		},
 		url: {
 			type: String,

--- a/Server/index.js
+++ b/Server/index.js
@@ -28,6 +28,7 @@ import NetworkService from "./service/networkService.js";
 import axios from "axios";
 import ping from "ping";
 import http from "http";
+import Docker from "dockerode";
 
 // Email service and dependencies
 import EmailService from "./service/emailService.js";
@@ -45,7 +46,7 @@ import NotificationService from "./service/notificationService.js";
 
 import db from "./db/mongo/MongoDB.js";
 const SERVICE_NAME = "Server";
-const SHUTDOWN_TIMEOUT = 0;
+const SHUTDOWN_TIMEOUT = 1000;
 
 let isShuttingDown = false;
 const __filename = fileURLToPath(import.meta.url);
@@ -130,7 +131,7 @@ const startApp = async () => {
 		nodemailer,
 		logger
 	);
-	const networkService = new NetworkService(axios, ping, logger, http);
+	const networkService = new NetworkService(axios, ping, logger, http, Docker);
 	const statusService = new StatusService(db, logger);
 	const notificationService = new NotificationService(emailService, db, logger);
 	const jobQueue = await JobQueue.createJobQueue(

--- a/Server/package-lock.json
+++ b/Server/package-lock.json
@@ -14,6 +14,7 @@
 				"bcrypt": "^5.1.1",
 				"bullmq": "5.25.6",
 				"cors": "^2.8.5",
+				"dockerode": "4.0.2",
 				"dotenv": "^16.4.5",
 				"express": "^4.19.2",
 				"handlebars": "^4.7.8",
@@ -88,6 +89,12 @@
 			"engines": {
 				"node": ">=6.9.0"
 			}
+		},
+		"node_modules/@balena/dockerignore": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@balena/dockerignore/-/dockerignore-1.0.2.tgz",
+			"integrity": "sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==",
+			"license": "Apache-2.0"
 		},
 		"node_modules/@bcoe/v8-coverage": {
 			"version": "0.2.3",
@@ -996,6 +1003,15 @@
 			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
 			"integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
 		},
+		"node_modules/asn1": {
+			"version": "0.2.6",
+			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+			"integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+			"license": "MIT",
+			"dependencies": {
+				"safer-buffer": "~2.1.0"
+			}
+		},
 		"node_modules/assertion-error": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1032,6 +1048,26 @@
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
 		},
+		"node_modules/base64-js": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
+		},
 		"node_modules/bcrypt": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-5.1.1.tgz",
@@ -1045,6 +1081,15 @@
 				"node": ">= 10.0.0"
 			}
 		},
+		"node_modules/bcrypt-pbkdf": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+			"integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"tweetnacl": "^0.14.3"
+			}
+		},
 		"node_modules/binary-extensions": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -1054,6 +1099,17 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/bl": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+			"integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+			"license": "MIT",
+			"dependencies": {
+				"buffer": "^5.5.0",
+				"inherits": "^2.0.4",
+				"readable-stream": "^3.4.0"
 			}
 		},
 		"node_modules/body-parser": {
@@ -1152,6 +1208,30 @@
 				"node": ">=16.20.1"
 			}
 		},
+		"node_modules/buffer": {
+			"version": "5.7.1",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+			"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"base64-js": "^1.3.1",
+				"ieee754": "^1.1.13"
+			}
+		},
 		"node_modules/buffer-equal-constant-time": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
@@ -1162,6 +1242,15 @@
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
 			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
 			"license": "MIT"
+		},
+		"node_modules/buildcheck": {
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.6.tgz",
+			"integrity": "sha512-8f9ZJCUXyT1M35Jx7MkBgmBMo3oHTTBIPLiY9xyL0pl3T5RwcPEY8cUHr5LBNfu/fk6c2T4DJZuVM/8ZZT2D2A==",
+			"optional": true,
+			"engines": {
+				"node": ">=10.0.0"
+			}
 		},
 		"node_modules/bullmq": {
 			"version": "5.25.6",
@@ -1708,6 +1797,20 @@
 				}
 			}
 		},
+		"node_modules/cpu-features": {
+			"version": "0.0.10",
+			"resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.10.tgz",
+			"integrity": "sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==",
+			"hasInstallScript": true,
+			"optional": true,
+			"dependencies": {
+				"buildcheck": "~0.0.6",
+				"nan": "^2.19.0"
+			},
+			"engines": {
+				"node": ">=10.0.0"
+			}
+		},
 		"node_modules/cron-parser": {
 			"version": "4.9.0",
 			"resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-4.9.0.tgz",
@@ -2014,6 +2117,58 @@
 				"node": ">=0.3.1"
 			}
 		},
+		"node_modules/docker-modem": {
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-5.0.3.tgz",
+			"integrity": "sha512-89zhop5YVhcPEt5FpUFGr3cDyceGhq/F9J+ZndQ4KfqNvfbJpPMfgeixFgUj5OjCYAboElqODxY5Z1EBsSa6sg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"debug": "^4.1.1",
+				"readable-stream": "^3.5.0",
+				"split-ca": "^1.0.1",
+				"ssh2": "^1.15.0"
+			},
+			"engines": {
+				"node": ">= 8.0"
+			}
+		},
+		"node_modules/docker-modem/node_modules/debug": {
+			"version": "4.3.7",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+			"integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+			"license": "MIT",
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/docker-modem/node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"license": "MIT"
+		},
+		"node_modules/dockerode": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/dockerode/-/dockerode-4.0.2.tgz",
+			"integrity": "sha512-9wM1BVpVMFr2Pw3eJNXrYYt6DT9k0xMcsSCjtPvyQ+xa1iPg/Mo3T/gUcwI0B2cczqCeCYRPF8yFYDwtFXT0+w==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@balena/dockerignore": "^1.0.2",
+				"docker-modem": "^5.0.3",
+				"tar-fs": "~2.0.1"
+			},
+			"engines": {
+				"node": ">= 8.0"
+			}
+		},
 		"node_modules/dom-serializer": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
@@ -2143,6 +2298,15 @@
 			},
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/end-of-stream": {
+			"version": "1.4.4",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+			"integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+			"license": "MIT",
+			"dependencies": {
+				"once": "^1.4.0"
 			}
 		},
 		"node_modules/entities": {
@@ -2438,6 +2602,12 @@
 			"engines": {
 				"node": ">= 0.6"
 			}
+		},
+		"node_modules/fs-constants": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+			"integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+			"license": "MIT"
 		},
 		"node_modules/fs-minipass": {
 			"version": "2.1.0",
@@ -2821,6 +2991,26 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
+		},
+		"node_modules/ieee754": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/ignore-by-default": {
 			"version": "1.0.1",
@@ -4129,6 +4319,12 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/mkdirp-classic": {
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+			"integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+			"license": "MIT"
+		},
 		"node_modules/mocha": {
 			"version": "10.8.2",
 			"resolved": "https://registry.npmjs.org/mocha/-/mocha-10.8.2.tgz",
@@ -4502,6 +4698,13 @@
 			"bin": {
 				"mkdirp": "bin/cmd.js"
 			}
+		},
+		"node_modules/nan": {
+			"version": "2.22.0",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.22.0.tgz",
+			"integrity": "sha512-nbajikzWTMwsW+eSsNm3QwlOs7het9gGJU5dDZzRTQGk03vyBOauxgI4VakDzE0PtsGTmXPsXTbbjVhRwR5mpw==",
+			"license": "MIT",
+			"optional": true
 		},
 		"node_modules/nanoid": {
 			"version": "3.3.7",
@@ -5553,6 +5756,16 @@
 			"integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
 			"dev": true
 		},
+		"node_modules/pump": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
+			"integrity": "sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==",
+			"license": "MIT",
+			"dependencies": {
+				"end-of-stream": "^1.1.0",
+				"once": "^1.3.1"
+			}
+		},
 		"node_modules/punycode": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -6046,6 +6259,29 @@
 				"memory-pager": "^1.0.2"
 			}
 		},
+		"node_modules/split-ca": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/split-ca/-/split-ca-1.0.1.tgz",
+			"integrity": "sha512-Q5thBSxp5t8WPTTJQS59LrGqOZqOsrhDGDVm8azCqIBjSBd7nd9o2PM+mDulQQkh8h//4U6hFZnc/mul8t5pWQ==",
+			"license": "ISC"
+		},
+		"node_modules/ssh2": {
+			"version": "1.16.0",
+			"resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.16.0.tgz",
+			"integrity": "sha512-r1X4KsBGedJqo7h8F5c4Ybpcr5RjyP+aWIG007uBPRjmdQWfEiVLzSK71Zji1B9sKxwaCvD8y8cwSkYrlLiRRg==",
+			"hasInstallScript": true,
+			"dependencies": {
+				"asn1": "^0.2.6",
+				"bcrypt-pbkdf": "^1.0.2"
+			},
+			"engines": {
+				"node": ">=10.16.0"
+			},
+			"optionalDependencies": {
+				"cpu-features": "~0.0.10",
+				"nan": "^2.20.0"
+			}
+		},
 		"node_modules/ssl-checker": {
 			"version": "2.0.10",
 			"resolved": "https://registry.npmjs.org/ssl-checker/-/ssl-checker-2.0.10.tgz",
@@ -6248,6 +6484,40 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/tar-fs": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.0.1.tgz",
+			"integrity": "sha512-6tzWDMeroL87uF/+lin46k+Q+46rAJ0SyPGz7OW7wTgblI273hsBqk2C1j0/xNadNLKDTUL9BukSjB7cwgmlPA==",
+			"license": "MIT",
+			"dependencies": {
+				"chownr": "^1.1.1",
+				"mkdirp-classic": "^0.5.2",
+				"pump": "^3.0.0",
+				"tar-stream": "^2.0.0"
+			}
+		},
+		"node_modules/tar-fs/node_modules/chownr": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+			"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+			"license": "ISC"
+		},
+		"node_modules/tar-stream": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+			"integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+			"license": "MIT",
+			"dependencies": {
+				"bl": "^4.0.3",
+				"end-of-stream": "^1.4.1",
+				"fs-constants": "^1.0.0",
+				"inherits": "^2.0.3",
+				"readable-stream": "^3.1.1"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/text-hex": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
@@ -6310,6 +6580,12 @@
 			"version": "2.6.3",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
 			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
+		},
+		"node_modules/tweetnacl": {
+			"version": "0.14.5",
+			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+			"integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
+			"license": "Unlicense"
 		},
 		"node_modules/type-detect": {
 			"version": "4.0.8",

--- a/Server/package.json
+++ b/Server/package.json
@@ -17,6 +17,7 @@
 		"bcrypt": "^5.1.1",
 		"bullmq": "5.25.6",
 		"cors": "^2.8.5",
+		"dockerode": "4.0.2",
 		"dotenv": "^16.4.5",
 		"express": "^4.19.2",
 		"handlebars": "^4.7.8",

--- a/Server/service/jobQueue.js
+++ b/Server/service/jobQueue.js
@@ -178,10 +178,11 @@ class JobQueue {
 					prevStatus,
 				});
 			} catch (error) {
+				console.log(error.service);
 				this.logger.error({
 					message: error.message,
-					service: SERVICE_NAME,
-					method: "createWorker",
+					service: error.service ?? SERVICE_NAME,
+					method: error.method ?? "createJobHandler",
 					details: `Error processing job ${job.id}: ${error.message}`,
 					stack: error.stack,
 				});

--- a/Server/service/jobQueue.js
+++ b/Server/service/jobQueue.js
@@ -178,7 +178,6 @@ class JobQueue {
 					prevStatus,
 				});
 			} catch (error) {
-				console.log(error.service);
 				this.logger.error({
 					message: error.message,
 					service: error.service ?? SERVICE_NAME,

--- a/Server/service/networkService.js
+++ b/Server/service/networkService.js
@@ -8,7 +8,7 @@ import { errorMessages, successMessages } from "../utils/messages.js";
  * @param {Object} http - The HTTP utility for network operations.
  */
 class NetworkService {
-	constructor(axios, ping, logger, http) {
+	constructor(axios, ping, logger, http, Docker) {
 		this.TYPE_PING = "ping";
 		this.TYPE_HTTP = "http";
 		this.TYPE_PAGESPEED = "pagespeed";
@@ -21,6 +21,7 @@ class NetworkService {
 		this.ping = ping;
 		this.logger = logger;
 		this.http = http;
+		this.Docker = Docker;
 	}
 
 	/**
@@ -164,7 +165,8 @@ class NetworkService {
 	}
 
 	async requestDocker(job) {
-		console.log(job);
+		var docker = new Docker({ socketPath: "/var/run/docker.sock" });
+
 		return {};
 	}
 

--- a/Server/service/networkService.js
+++ b/Server/service/networkService.js
@@ -13,6 +13,7 @@ class NetworkService {
 		this.TYPE_HTTP = "http";
 		this.TYPE_PAGESPEED = "pagespeed";
 		this.TYPE_HARDWARE = "hardware";
+		this.TYPE_DOCKER = "docker";
 		this.SERVICE_NAME = "NetworkService";
 		this.NETWORK_ERROR = 5000;
 		this.PING_ERROR = 5001;
@@ -162,6 +163,11 @@ class NetworkService {
 		return this.requestHttp(job);
 	}
 
+	async requestDocker(job) {
+		console.log(job);
+		return {};
+	}
+
 	/**
 	 * Gets the status of a job based on its type and returns the appropriate response.
 	 *
@@ -181,13 +187,13 @@ class NetworkService {
 				return await this.requestPagespeed(job);
 			case this.TYPE_HARDWARE:
 				return await this.requestHardware(job);
+			case this.TYPE_DOCKER:
+				return await this.requestDocker(job);
 			default:
-				this.logger.error({
-					message: `Unsupported type: ${job.data.type}`,
-					service: this.SERVICE_NAME,
-					method: "getStatus",
-				});
-				return {};
+				const err = new Error(`Unsupported type: ${job.data.type}`);
+				err.service = this.SERVICE_NAME;
+				err.method = "getStatus";
+				throw err;
 		}
 	}
 }

--- a/Server/service/networkService.js
+++ b/Server/service/networkService.js
@@ -172,8 +172,6 @@ class NetworkService {
 			container.inspect()
 		);
 
-		const containerState = response?.State ?? {};
-
 		const dockerResponse = {
 			monitorId: job.data._id,
 			type: job.data.type,
@@ -187,7 +185,7 @@ class NetworkService {
 			dockerResponse.message = error.reason || errorMessages.DOCKER_FAIL;
 			return dockerResponse;
 		}
-		dockerResponse.status = containerState.Status === "running" ? true : false;
+		dockerResponse.status = response?.State?.Status === "running" ? true : false;
 		dockerResponse.code = 200;
 		dockerResponse.message = successMessages.DOCKER_SUCCESS;
 		return dockerResponse;

--- a/Server/service/statusService.js
+++ b/Server/service/statusService.js
@@ -133,6 +133,7 @@ class StatusService {
 				ping: this.db.createCheck,
 				pagespeed: this.db.createPageSpeedCheck,
 				hardware: this.db.createHardwareCheck,
+				docker: this.db.createCheck,
 			};
 			const operation = operationMap[networkResponse.type];
 

--- a/Server/utils/messages.js
+++ b/Server/utils/messages.js
@@ -55,6 +55,9 @@ const errorMessages = {
 	// Status Page Errors
 	STATUS_PAGE_NOT_FOUND: "Status page not found",
 	STATUS_PAGE_URL_NOT_UNIQUE: "Status page url must be unique",
+
+	// Docker
+	DOCKER_FAIL: "Failed to fetch Docker container information",
 };
 
 const successMessages = {
@@ -123,6 +126,9 @@ const successMessages = {
 	// Status Page
 	STATUS_PAGE_BY_URL: "Got status page by url successfully",
 	STATUS_PAGE_CREATE: "Status page created successfully",
+
+	// Docker
+	DOCKER_SUCCESS: "Docker container status fetched successfully",
 };
 
 export { errorMessages, successMessages };

--- a/Server/utils/messages.js
+++ b/Server/utils/messages.js
@@ -58,6 +58,7 @@ const errorMessages = {
 
 	// Docker
 	DOCKER_FAIL: "Failed to fetch Docker container information",
+	DOCKER_NOT_FOUND: "Docker container not found",
 };
 
 const successMessages = {


### PR DESCRIPTION
This PR adds support for a docker monitor.  This is a subtype of uptime monitor.

- [x] Use [dockerode](https://www.npmjs.com/package/dockerode/v/2.5.5) for daemon connection
  - [x] Currnently only support connection via unix socket.  This can later be changed to include http/https operations.
-[x] Update JobQueue, NetworkSerivce, and StatusService to support docker type monitors

Currently there is no need for a distinct docker type check as we are currently only interested in whether or not the container is running.  This is the same information that we have for a base http/ping type `Check`, so that type is used.  We can implement a distinct docker type check if we need more information later.

Docker monitors use a docker image ID in the `url` field of the monitor. 