### PR TITLE
Remove sendgrid dependency from BE

### DIFF
--- a/Server/package-lock.json
+++ b/Server/package-lock.json
@@ -9,7 +9,6 @@
 			"version": "1.0.0",
 			"license": "ISC",
 			"dependencies": {
-				"@sendgrid/mail": "^8.1.3",
 				"axios": "^1.7.2",
 				"bcrypt": "^5.1.1",
 				"bullmq": "5.25.6",
@@ -743,41 +742,6 @@
 			"optional": true,
 			"engines": {
 				"node": ">=14"
-			}
-		},
-		"node_modules/@sendgrid/client": {
-			"version": "8.1.3",
-			"resolved": "https://registry.npmjs.org/@sendgrid/client/-/client-8.1.3.tgz",
-			"integrity": "sha512-mRwTticRZIdUTsnyzvlK6dMu3jni9ci9J+dW/6fMMFpGRAJdCJlivFVYQvqk8kRS3RnFzS7sf6BSmhLl1ldDhA==",
-			"dependencies": {
-				"@sendgrid/helpers": "^8.0.0",
-				"axios": "^1.6.8"
-			},
-			"engines": {
-				"node": ">=12.*"
-			}
-		},
-		"node_modules/@sendgrid/helpers": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/@sendgrid/helpers/-/helpers-8.0.0.tgz",
-			"integrity": "sha512-Ze7WuW2Xzy5GT5WRx+yEv89fsg/pgy3T1E3FS0QEx0/VvRmigMZ5qyVGhJz4SxomegDkzXv/i0aFPpHKN8qdAA==",
-			"dependencies": {
-				"deepmerge": "^4.2.2"
-			},
-			"engines": {
-				"node": ">= 12.0.0"
-			}
-		},
-		"node_modules/@sendgrid/mail": {
-			"version": "8.1.3",
-			"resolved": "https://registry.npmjs.org/@sendgrid/mail/-/mail-8.1.3.tgz",
-			"integrity": "sha512-Wg5iKSUOER83/cfY6rbPa+o3ChnYzWwv1OcsR8gCV8SKi+sUPIMroildimlnb72DBkQxcbylxng1W7f0RIX7MQ==",
-			"dependencies": {
-				"@sendgrid/client": "^8.1.3",
-				"@sendgrid/helpers": "^8.0.0"
-			},
-			"engines": {
-				"node": ">=12.*"
 			}
 		},
 		"node_modules/@sideway/address": {
@@ -2028,14 +1992,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
-			}
-		},
-		"node_modules/deepmerge": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
-			"integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/define-data-property": {

--- a/Server/package.json
+++ b/Server/package.json
@@ -12,7 +12,6 @@
 	"author": "",
 	"license": "ISC",
 	"dependencies": {
-		"@sendgrid/mail": "^8.1.3",
 		"axios": "^1.7.2",
 		"bcrypt": "^5.1.1",
 		"bullmq": "5.25.6",


### PR DESCRIPTION
This PR removes the sendgrid dependency from the backend.  Sendgrid was used to send emails in the past, we are using nodemailer now.