### PR TITLE
Feat/fe/infrastrucutre area chart, resolves #1069

### DIFF
--- a/Client/src/Components/Charts/AreaChart/data.js
+++ b/Client/src/Components/Charts/AreaChart/data.js
@@ -1,0 +1,59 @@
+const ObjectId = (string) => string;
+const ISODate = (string) => string;
+
+// Helper to generate random percentage between 0.1 and 1.0
+const randomPercent = () => Number((Math.random() * 0.9 + 0.1).toFixed(2));
+
+// Create base timestamp and increment by 5 minutes for each entry
+const baseTime = new Date("2024-11-15T07:00:00.000Z");
+const checks = Array.from({ length: 20 }, (_, index) => {
+	const timestamp = new Date(baseTime.getTime() + index * 5 * 60 * 1000);
+
+	return {
+		_id: ObjectId(`6736f4f449e23954c8b89a${index.toString(16).padStart(2, "0")}`),
+		monitorId: ObjectId("6736e6c2939f02e0ca519465"),
+		status: true,
+		responseTime: Math.floor(Math.random() * 50) + 80, // Random between 80-130ms
+		statusCode: 200,
+		message: "OK",
+		cpu: {
+			physical_core: 0,
+			logical_core: 0,
+			frequency: 0,
+			temperature: 0,
+			free_percent: 0,
+			usage_percent: randomPercent(),
+			_id: ObjectId(`6736f4f449e23954c8b89b${index.toString(16).padStart(2, "0")}`),
+		},
+		memory: {
+			total_bytes: 0,
+			available_bytes: 0,
+			used_bytes: 0,
+			usage_percent: randomPercent(),
+			_id: ObjectId(`6736f4f449e23954c8b89c${index.toString(16).padStart(2, "0")}`),
+		},
+		disk: [
+			{
+				read_speed_bytes: 0,
+				write_speed_bytes: 0,
+				total_bytes: 0,
+				free_bytes: 0,
+				usage_percent: randomPercent(),
+				_id: ObjectId(`6736f4f449e23954c8b89d${index.toString(16).padStart(2, "0")}`),
+			},
+		],
+		host: {
+			os: "",
+			platform: "",
+			kernel_version: "",
+			_id: ObjectId(`6736f4f449e23954c8b89e${index.toString(16).padStart(2, "0")}`),
+		},
+		errors: [],
+		expiry: ISODate(new Date(timestamp.getTime() + 24 * 60 * 60 * 1000).toISOString()),
+		createdAt: ISODate(timestamp.toISOString()),
+		updatedAt: ISODate(timestamp.toISOString()),
+		__v: 0,
+	};
+});
+
+export default checks;

--- a/Client/src/Components/Charts/AreaChart/index.jsx
+++ b/Client/src/Components/Charts/AreaChart/index.jsx
@@ -11,6 +11,56 @@ import { createGradient } from "../Utils/gradientUtils";
 import PropTypes from "prop-types";
 import { useTheme } from "@mui/material";
 
+/**
+ * CustomAreaChart component for rendering an area chart with optional gradient and custom ticks.
+ *
+ * @param {Object} props - The properties object.
+ * @param {Array} props.data - The data array for the chart.
+ * @param {string} props.xKey - The key for the x-axis data.
+ * @param {string} props.yKey - The key for the y-axis data.
+ * @param {Object} [props.xTick] - Custom tick component for the x-axis.
+ * @param {Object} [props.yTick] - Custom tick component for the y-axis.
+ * @param {string} [props.strokeColor] - The stroke color for the area.
+ * @param {string} [props.fillColor] - The fill color for the area.
+ * @param {boolean} [props.gradient=false] - Whether to apply a gradient fill.
+ * @param {string} [props.gradientDirection="vertical"] - The direction of the gradient.
+ * @param {string} [props.gradientStartColor] - The start color of the gradient.
+ * @param {string} [props.gradientEndColor] - The end color of the gradient.
+ * @param {Object} [props.customTooltip] - Custom tooltip component.
+ * @returns {JSX.Element} The rendered area chart component.
+ *
+ * @example
+ * // Example usage of CustomAreaChart
+ * import React from 'react';
+ * import CustomAreaChart from './CustomAreaChart';
+ * import { TzTick, PercentTick, InfrastructureTooltip } from './chartUtils';
+ *
+ * const data = [
+ *   { createdAt: '2023-01-01T00:00:00Z', cpu: { usage_percent: 0.5 } },
+ *   { createdAt: '2023-01-01T01:00:00Z', cpu: { usage_percent: 0.6 } },
+ *   // more data points...
+ * ];
+ *
+ * const MyChartComponent = () => {
+ *   return (
+ *     <CustomAreaChart
+ *       data={data}
+ *       xKey="createdAt"
+ *       yKey="cpu.usage_percent"
+ *       xTick={TzTick}
+ *       yTick={PercentTick}
+ *       strokeColor="#8884d8"
+ *       fillColor="#8884d8"
+ *       gradient={true}
+ *       gradientStartColor="#8884d8"
+ *       gradientEndColor="#82ca9d"
+ *       customTooltip={InfrastructureTooltip}
+ *     />
+ *   );
+ * };
+ *
+ * export default MyChartComponent;
+ */
 const CustomAreaChart = ({
 	data,
 	xKey,

--- a/Client/src/Components/Charts/AreaChart/index.jsx
+++ b/Client/src/Components/Charts/AreaChart/index.jsx
@@ -1,0 +1,92 @@
+import {
+	AreaChart,
+	Area,
+	XAxis,
+	YAxis,
+	CartesianGrid,
+	Tooltip,
+	ResponsiveContainer,
+} from "recharts";
+import { createGradient } from "../Utils/gradientUtils";
+import PropTypes from "prop-types";
+import { useTheme } from "@mui/material";
+
+const CustomAreaChart = ({
+	data,
+	xKey,
+	yKey,
+	xTick,
+	yTick,
+	strokeColor,
+	fillColor,
+	gradient = false,
+	gradientDirection = "vertical",
+	gradientStartColor,
+	gradientEndColor,
+	customTooltip,
+}) => {
+	const theme = useTheme();
+	return (
+		<ResponsiveContainer
+			width="100%"
+			height="100%"
+		>
+			<AreaChart data={data}>
+				<XAxis
+					dataKey={xKey}
+					{...(xTick && { tick: xTick })}
+				/>
+				<YAxis
+					dataKey={yKey}
+					{...(yTick && { tick: yTick })}
+				/>
+				{gradient === true &&
+					createGradient({
+						startColor: gradientStartColor,
+						endColor: gradientEndColor,
+						direction: gradientDirection,
+					})}
+				<CartesianGrid
+					stroke={theme.palette.border.light}
+					strokeWidth={1}
+					strokeOpacity={1}
+					fill="transparent"
+					vertical={false}
+				/>
+				<Area
+					type="monotone"
+					dataKey="cpu.usage_percent"
+					stroke={strokeColor}
+					fill={gradient === true ? "url(#colorUv)" : fillColor}
+				/>
+
+				{customTooltip ? (
+					<Tooltip
+						cursor={{ stroke: theme.palette.border.light }}
+						content={customTooltip}
+						wrapperStyle={{ pointerEvents: "none" }}
+					/>
+				) : (
+					<Tooltip />
+				)}
+			</AreaChart>
+		</ResponsiveContainer>
+	);
+};
+
+CustomAreaChart.propTypes = {
+	data: PropTypes.array.isRequired,
+	xTick: PropTypes.object, // Recharts takes an instance of component, so we can't pass the component itself
+	yTick: PropTypes.object, // Recharts takes an instance of component, so we can't pass the component itself
+	xKey: PropTypes.string.isRequired,
+	yKey: PropTypes.string.isRequired,
+	fillColor: PropTypes.string,
+	strokeColor: PropTypes.string,
+	gradient: PropTypes.bool,
+	gradientDirection: PropTypes.string,
+	gradientStartColor: PropTypes.string,
+	gradientEndColor: PropTypes.string,
+	customTooltip: PropTypes.object,
+};
+
+export default CustomAreaChart;

--- a/Client/src/Components/Charts/AreaChart/index.jsx
+++ b/Client/src/Components/Charts/AreaChart/index.jsx
@@ -63,6 +63,7 @@ import { useTheme } from "@mui/material";
  */
 const CustomAreaChart = ({
 	data,
+	dataKey,
 	xKey,
 	yKey,
 	xTick,
@@ -105,7 +106,7 @@ const CustomAreaChart = ({
 				/>
 				<Area
 					type="monotone"
-					dataKey="cpu.usage_percent"
+					dataKey={dataKey}
 					stroke={strokeColor}
 					fill={gradient === true ? "url(#colorUv)" : fillColor}
 				/>
@@ -126,6 +127,7 @@ const CustomAreaChart = ({
 
 CustomAreaChart.propTypes = {
 	data: PropTypes.array.isRequired,
+	dataKey: PropTypes.string.isRequired,
 	xTick: PropTypes.object, // Recharts takes an instance of component, so we can't pass the component itself
 	yTick: PropTypes.object, // Recharts takes an instance of component, so we can't pass the component itself
 	xKey: PropTypes.string.isRequired,

--- a/Client/src/Components/Charts/Utils/chartUtils.jsx
+++ b/Client/src/Components/Charts/Utils/chartUtils.jsx
@@ -4,12 +4,21 @@ import { useTheme } from "@mui/material";
 import { Text } from "recharts";
 import { formatDateWithTz } from "../../../Utils/timeUtils";
 import { Box, Stack, Typography } from "@mui/material";
+
+/**
+ * Custom tick component for rendering time with timezone.
+ *
+ * @param {Object} props - The properties object.
+ * @param {number} props.x - The x-coordinate for the tick.
+ * @param {number} props.y - The y-coordinate for the tick.
+ * @param {Object} props.payload - The payload object containing tick data.
+ * @param {number} props.index - The index of the tick.
+ * @returns {JSX.Element} The rendered tick component.
+ */
 export const TzTick = ({ x, y, payload, index }) => {
 	const theme = useTheme();
 
 	const uiTimezone = useSelector((state) => state.ui.timezone);
-
-	// Render nothing for the first tick
 	return (
 		<Text
 			x={x}
@@ -31,6 +40,16 @@ TzTick.propTypes = {
 	index: PropTypes.number,
 };
 
+/**
+ * Custom tick component for rendering percentage values.
+ *
+ * @param {Object} props - The properties object.
+ * @param {number} props.x - The x-coordinate for the tick.
+ * @param {number} props.y - The y-coordinate for the tick.
+ * @param {Object} props.payload - The payload object containing tick data.
+ * @param {number} props.index - The index of the tick.
+ * @returns {JSX.Element|null} The rendered tick component or null for the first tick.
+ */
 export const PercentTick = ({ x, y, payload, index }) => {
 	const theme = useTheme();
 	if (index === 0) return null;
@@ -55,6 +74,18 @@ PercentTick.propTypes = {
 	index: PropTypes.number,
 };
 
+/**
+ * Custom tooltip component for displaying infrastructure data.
+ *
+ * @param {Object} props - The properties object.
+ * @param {boolean} props.active - Indicates if the tooltip is active.
+ * @param {Array} props.payload - The payload array containing tooltip data.
+ * @param {string} props.label - The label for the tooltip.
+ * @param {string} props.yKey - The key for the y-axis data.
+ * @param {string} props.yLabel - The label for the y-axis data.
+ * @param {string} props.dotColor - The color of the dot in the tooltip.
+ * @returns {JSX.Element|null} The rendered tooltip component or null if inactive.
+ */
 export const InfrastructureTooltip = ({
 	active,
 	payload,

--- a/Client/src/Components/Charts/Utils/chartUtils.jsx
+++ b/Client/src/Components/Charts/Utils/chartUtils.jsx
@@ -1,0 +1,135 @@
+import PropTypes from "prop-types";
+import { useSelector } from "react-redux";
+import { useTheme } from "@mui/material";
+import { Text } from "recharts";
+import { formatDateWithTz } from "../../../Utils/timeUtils";
+import { Box, Stack, Typography } from "@mui/material";
+export const TzTick = ({ x, y, payload, index }) => {
+	const theme = useTheme();
+
+	const uiTimezone = useSelector((state) => state.ui.timezone);
+
+	// Render nothing for the first tick
+	return (
+		<Text
+			x={x}
+			y={y + 10}
+			textAnchor="middle"
+			fill={theme.palette.text.tertiary}
+			fontSize={11}
+			fontWeight={400}
+		>
+			{formatDateWithTz(payload?.value, "h:mm a", uiTimezone)}
+		</Text>
+	);
+};
+
+TzTick.propTypes = {
+	x: PropTypes.number,
+	y: PropTypes.number,
+	payload: PropTypes.object,
+	index: PropTypes.number,
+};
+
+export const PercentTick = ({ x, y, payload, index }) => {
+	const theme = useTheme();
+	if (index === 0) return null;
+	return (
+		<Text
+			x={x - 20}
+			y={y}
+			textAnchor="middle"
+			fill={theme.palette.text.tertiary}
+			fontSize={11}
+			fontWeight={400}
+		>
+			{`${payload?.value * 100}%`}
+		</Text>
+	);
+};
+
+PercentTick.propTypes = {
+	x: PropTypes.number,
+	y: PropTypes.number,
+	payload: PropTypes.object,
+	index: PropTypes.number,
+};
+
+export const InfrastructureTooltip = ({
+	active,
+	payload,
+	label,
+	yKey,
+	yLabel,
+	dotColor,
+}) => {
+	const uiTimezone = useSelector((state) => state.ui.timezone);
+	const theme = useTheme();
+	if (active && payload && payload.length) {
+		const [hardwareType, metric] = yKey.split(".");
+		return (
+			<Box
+				className="area-tooltip"
+				sx={{
+					backgroundColor: theme.palette.background.main,
+					border: 1,
+					borderColor: theme.palette.border.dark,
+					borderRadius: theme.shape.borderRadius,
+					py: theme.spacing(2),
+					px: theme.spacing(4),
+				}}
+			>
+				<Typography
+					sx={{
+						color: theme.palette.text.tertiary,
+						fontSize: 12,
+						fontWeight: 500,
+					}}
+				>
+					{formatDateWithTz(label, "ddd, MMMM D, YYYY, h:mm A", uiTimezone)}
+				</Typography>
+				<Box mt={theme.spacing(1)}>
+					<Box
+						display="inline-block"
+						width={theme.spacing(4)}
+						height={theme.spacing(4)}
+						backgroundColor={dotColor}
+						sx={{ borderRadius: "50%" }}
+					/>
+					<Stack
+						display="inline-flex"
+						direction="row"
+						justifyContent="space-between"
+						ml={theme.spacing(3)}
+						sx={{
+							"& span": {
+								color: theme.palette.text.tertiary,
+								fontSize: 11,
+								fontWeight: 500,
+							},
+						}}
+					>
+						<Typography
+							component="span"
+							sx={{ opacity: 0.8 }}
+						>
+							{`${yLabel} ${payload[0].payload[hardwareType][metric] * 100}%`}
+						</Typography>
+						<Typography component="span"></Typography>
+					</Stack>
+				</Box>
+				{/* Display original value */}
+			</Box>
+		);
+	}
+	return null;
+};
+
+InfrastructureTooltip.propTypes = {
+	active: PropTypes.bool,
+	payload: PropTypes.array,
+	label: PropTypes.string,
+	yKey: PropTypes.string,
+	yLabel: PropTypes.string,
+	dotColor: PropTypes.string,
+};

--- a/Client/src/Components/Charts/Utils/gradientUtils.jsx
+++ b/Client/src/Components/Charts/Utils/gradientUtils.jsx
@@ -1,0 +1,47 @@
+/**
+ * Creates an SVG gradient definition for use in charts
+ * @param {Object} params - The gradient parameters
+ * @param {string} [params.id="colorUv"] - Unique identifier for the gradient
+ * @param {string} params.startColor - Starting color of the gradient (hex, rgb, or color name)
+ * @param {string} params.endColor - Ending color of the gradient (hex, rgb, or color name)
+ * @param {number} [params.startOpacity=0.8] - Starting opacity (0-1)
+ * @param {number} [params.endOpacity=0] - Ending opacity (0-1)
+ * @param {('vertical'|'horizontal')} [params.direction="vertical"] - Direction of the gradient
+ * @returns {JSX.Element} SVG gradient definition element
+ * @example
+ * createCustomGradient({
+ *   startColor: "#1976D2",
+ *   endColor: "#42A5F5",
+ *   direction: "horizontal"
+ * })
+ */
+
+export const createGradient = ({
+	id = "colorUv",
+	startColor,
+	endColor,
+	startOpacity = 0.8,
+	endOpacity = 0,
+	direction = "vertical", // or "horizontal"
+}) => (
+	<defs>
+		<linearGradient
+			id={id}
+			x1={direction === "vertical" ? "0" : "0"}
+			y1={direction === "vertical" ? "0" : "0"}
+			x2={direction === "vertical" ? "0" : "1"}
+			y2={direction === "vertical" ? "1" : "0"}
+		>
+			<stop
+				offset="0%"
+				stopColor={startColor}
+				stopOpacity={startOpacity}
+			/>
+			<stop
+				offset="100%"
+				stopColor={endColor}
+				stopOpacity={endOpacity}
+			/>
+		</linearGradient>
+	</defs>
+);


### PR DESCRIPTION
This PR suggests an implementation for an area chart that we can use for not only Infrasructure Monitors, but also to replace the Monitor Details chart.

- [x] Implement a reusable generic area chart
  - [x] Supports custom xAxis and yAxis ticks
  - [x] Supports gradient or solid background  
  - [x] Supports custom tooltips 
- [x] Add a Utils directory for commonly used chart utils
- [ ] Refactor MonitorDetails chart to use the generic chart - Probably to be done in a new PR

![image](https://github.com/user-attachments/assets/8ffdad6e-9abd-45e0-9a16-b892e2be2d3a)
