### PR TITLE
fix: Remove top level package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "bluewave-uptime",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
Remove `/package-lock.json` that comes with pr-987. It not breaks anything because it's top level.