### PR TITLE
fix: rewrite BE endpoint resolution method

### DIFF
--- a/Server/controllers/monitorController.js
+++ b/Server/controllers/monitorController.js
@@ -19,7 +19,7 @@ import jwt from "jsonwebtoken";
 import { getTokenFromHeaders } from "../utils/utils.js";
 import logger from "../utils/logger.js";
 import { handleError, handleValidationError } from "./controllerUtils.js";
-import dns from "dns";
+import axios from "axios";
 
 const SERVICE_NAME = "monitorController";
 
@@ -288,18 +288,16 @@ const checkEndpointResolution = async (req, res, next) => {
 	}
 
 	try {
-		let { monitorURL } = req.query;
-		monitorURL = new URL(monitorURL);
-		await new Promise((resolve, reject) => {
-			dns.resolve(monitorURL.hostname, (error) => {
-				if (error) {
-					reject(error);
-				}
-				resolve();
-			});
+		const { monitorURL } = req.query;
+		const parsedUrl = new URL(monitorURL);
+		const response = await axios.get(parsedUrl, {
+			timeout: 5000,
+			validateStatus: () => true,
 		});
 		return res.status(200).json({
 			success: true,
+			code: response.status,
+			statusText: response.statusText,
 			msg: `URL resolved successfully`,
 		});
 	} catch (error) {


### PR DESCRIPTION
This PR rewrites the endpoint resolution functionality.  The original implementation was insufficient and only handle DNS resolution, which is only a subset of resolution we need to check.

- [x] use axios to check for endpoint resolution
  - [x] accepts all status code as resolution, we just want to know if the server is there or not and responding
  - [x] add statusCode and statusText to success response in case we need this later
- [x] update tests 