### PR TITLE
set initial loading state to false, resolves #1182

### DIFF
--- a/Client/src/Pages/Incidents/IncidentTable/index.jsx
+++ b/Client/src/Pages/Incidents/IncidentTable/index.jsx
@@ -39,7 +39,7 @@ const IncidentTable = ({ monitors, selectedMonitor, filter }) => {
 		page: 0,
 		rowsPerPage: 14,
 	});
-	const [isLoading, setIsLoading] = useState(true);
+	const [isLoading, setIsLoading] = useState(false);
 
 	useEffect(() => {
 		setPaginationController((prevPaginationController) => ({


### PR DESCRIPTION
This PR changes the default `loading` state on the incident tage to `false`.  In the case when there are no monitors, the page returns without doing anything to the `loading` state, so the page is stuck in loading status.

This results in the wrong view presented when no monitors exist.

- [x] Set loading state to `false`.  It should only be set to `true` when a network operation begins.