### PR TITLE
Add better status string generation

### DIFF
--- a/Server/service/statusService.js
+++ b/Server/service/statusService.js
@@ -11,6 +11,11 @@ class StatusService {
 		this.SERVICE_NAME = "StatusService";
 	}
 
+	getStatusString = (status) => {
+		if (status === true) return "up";
+		if (status === false) return "down";
+		return "unknown";
+	};
 	/**
 	 * Updates the status of a monitor based on the network response.
 	 *
@@ -34,7 +39,7 @@ class StatusService {
 
 			this.logger.info({
 				service: this.SERVICE_NAME,
-				message: `${monitor.name} went from ${monitor.status === true ? "up" : "down"} to ${status === true ? "up" : "down"}`,
+				message: `${monitor.name} went from ${this.getStatusString(monitor.status)} to ${this.getStatusString(status)}`,
 				prevStatus: monitor.status,
 				newStatus: status,
 			});

--- a/Server/tests/services/statusService.test.js
+++ b/Server/tests/services/statusService.test.js
@@ -27,6 +27,18 @@ describe("StatusService", () => {
 		});
 	});
 
+	describe("getStatusString", () => {
+		it("should return 'up' if status is true", () => {
+			expect(statusService.getStatusString(true)).to.equal("up");
+		});
+		it("should return 'down' if status is false", () => {
+			expect(statusService.getStatusString(false)).to.equal("down");
+		});
+		it("should return 'unknown' if status is undefined or null", () => {
+			expect(statusService.getStatusString(undefined)).to.equal("unknown");
+		});
+	});
+
 	describe("updateStatus", async () => {
 		beforeEach(() => {
 			// statusService.insertCheck = sinon.stub().resolves;


### PR DESCRIPTION
This PR improves status string generation for monitor status chagnes.  Previously if a monitor went from an unknown state to a down state the logger would log "monitor went from down to down".

Now the logger will correctly log "monitor went from unknown to down"

- [x] Add a function to generate status strings
- [x] Add tests 